### PR TITLE
[STYLE] rem 단위 도입 및 62.5% 기준 폰트 사이즈 설정

### DIFF
--- a/src/stories/button.css
+++ b/src/stories/button.css
@@ -17,14 +17,14 @@
   color: #333;
 }
 .storybook-button--small {
-  padding: 10px 16px;
-  font-size: 12px;
+  padding: 1rem 1.6rem;
+  font-size: 1.2rem;
 }
 .storybook-button--medium {
-  padding: 11px 20px;
-  font-size: 14px;
+  padding: 1.1rem 2rem;
+  font-size: 1.4rem;
 }
 .storybook-button--large {
-  padding: 12px 24px;
-  font-size: 16px;
+  padding: 1.2rem 2.4rem;
+  font-size: 1.6rem;
 }

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -35,12 +35,12 @@
 
   --font-sans: 'SUIT Variable', 'SUIT', sans-serif;
 
-  --text-headline1: 24px;
-  --text-headline2: 20px;
-  --text-title1: 18px;
-  --text-body1: 16px;
-  --text-body2: 14px;
-  --text-caption1: 12px;
+  --text-headline1: 2.4rem;
+  --text-headline2: 2rem;
+  --text-title1: 1.8rem;
+  --text-body1: 1.6rem;
+  --text-body2: 1.4rem;
+  --text-caption1: 1.2rem;
 
   --leading-headline1: 1.35;
   --leading-headline2: 1.4;
@@ -157,6 +157,7 @@
 
 @layer base {
   html {
+    font-size: 62.5%; /* 1rem = 10px */
     font-family: var(--font-sans);
   }
 }


### PR DESCRIPTION
## 📌 PR 제목

[STYLE] rem 단위 도입 및 62.5% 기준 폰트 사이즈 설정

---

## 🔗 관련 이슈 (Issue)

- Closes #24

---

## ✅ 작업 내용

rem 단위를 편리하게 사용하기 위해 `html`에 `font-size: 62.5%`를 적용해 `1rem = 10px` 기준을 도입했습니다.
기존에 `px`로 작성된 타이포그래피 토큰과 Storybook 버튼 스타일을 모두 `rem`으로 변환했습니다.
이제 `24px` → `2.4rem`처럼 소수점만 이동해 직관적으로 rem 값을 계산할 수 있습니다.

- `src/style/global.css`: `html`에 `font-size: 62.5%` 추가 (1rem = 10px 기준 확립)
- `src/style/global.css`: `--text-headline1` ~ `--text-caption1` 6개 토큰을 `px → rem`으로 변환
- `src/stories/button.css`: Storybook 버튼의 `padding`, `font-size` 값을 `px → rem`으로 변환

---

## 🖥️ 테스트 방법

1. 개발 서버 실행 (`npm run dev`)
2. 브라우저 개발자 도구에서 `html` 요소의 computed `font-size`가 `10px`인지 확인
3. 텍스트 스타일 클래스(`headline1-bold` 등) 적용 시 기존과 동일한 크기로 렌더링되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 버튼 크기 변형의 패딩과 글씨 크기를 고정 픽셀 값에서 rem 기반 값으로 변환했습니다.
  * 타이포그래피 크기를 픽셀에서 rem으로 변환하고 기본 글꼴 크기를 설정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->