### PR TITLE
[FEAT] ListItem 공통 컴포넌트 추가

### DIFF
--- a/src/components/common/ListItem/ListItem.stories.tsx
+++ b/src/components/common/ListItem/ListItem.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+import { ListItem } from './ListItem';
+
+const meta = {
+  title: 'common/ListItem',
+  component: ListItem,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  args: {
+    imageSrc: 'https://placehold.co/50x73',
+    imageAlt: '해리포터와 마법사의 돌 1 표지',
+    title: '해리포터와 마법사의 돌 1',
+    year: 2024,
+    publisher: '문학수첩',
+    onClick: fn(),
+    className: 'border-2 border-dashed border-gray-alpha-100',
+  },
+  decorators: [
+    (Story) => (
+      <ul className="w-142">
+        <Story />
+      </ul>
+    ),
+  ],
+} satisfies Meta<typeof ListItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    selected: false,
+    publisher: '문학수첩',
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    selected: true,
+    imageSrc: 'https://placehold.co/50x73',
+  },
+};

--- a/src/components/common/ListItem/ListItem.tsx
+++ b/src/components/common/ListItem/ListItem.tsx
@@ -1,4 +1,5 @@
 import { type VariantProps } from 'class-variance-authority';
+import Image from 'next/image';
 import { CheckIcon } from '@/components';
 import { cn } from '@/lib';
 import { listItemVariants } from './listItemVariants';
@@ -35,11 +36,7 @@ export const ListItem = (props: Props) => {
         className={cn(listItemVariants({ selected }), className)}
       >
         <div className="relative h-[7.3rem] w-20 shrink-0 overflow-hidden rounded-[0.6rem] border border-gray-alpha-100 shadow-[0_0_3.2rem_rgba(0,0,0,0.12)]">
-          <img
-            src={imageSrc}
-            alt={imageAlt}
-            className="pointer-events-none absolute inset-0 size-full object-cover"
-          />
+          <Image src={imageSrc} alt={imageAlt} fill className="pointer-events-none object-cover" />
         </div>
 
         <div className="flex min-w-0 flex-1 flex-col items-start">

--- a/src/components/common/ListItem/ListItem.tsx
+++ b/src/components/common/ListItem/ListItem.tsx
@@ -1,0 +1,63 @@
+import { type VariantProps } from 'class-variance-authority';
+import { CheckIcon } from '@/components';
+import { cn } from '@/lib';
+import { listItemVariants } from './listItemVariants';
+
+type Props = VariantProps<typeof listItemVariants> & {
+  imageSrc: string;
+  imageAlt?: string;
+  title: string;
+  year?: number;
+  publisher?: string;
+  selected?: boolean;
+  className?: string;
+  onClick?: () => void;
+};
+
+export const ListItem = (props: Props) => {
+  const {
+    imageSrc,
+    imageAlt = '',
+    title,
+    year = '2000',
+    publisher = '출판사/저자',
+    selected = false,
+    className,
+    onClick,
+  } = props;
+
+  return (
+    <li>
+      <button
+        type="button"
+        aria-pressed={selected}
+        onClick={onClick}
+        className={cn(listItemVariants({ selected }), className)}
+      >
+        <div className="relative h-[7.3rem] w-20 shrink-0 overflow-hidden rounded-[0.6rem] border border-gray-alpha-100 shadow-[0_0_3.2rem_rgba(0,0,0,0.12)]">
+          <img
+            src={imageSrc}
+            alt={imageAlt}
+            className="pointer-events-none absolute inset-0 size-full object-cover"
+          />
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col items-start">
+          <p className="title1-bold w-full truncate text-text-default">{title}</p>
+          <p className="body2-medium w-full truncate text-text-caption">
+            {`${year} | ${publisher}`}
+          </p>
+        </div>
+
+        {selected && (
+          <span
+            aria-hidden
+            className="relative flex size-[2.8rem] shrink-0 items-center justify-center rounded-full bg-linear-to-b from-[rgba(255,255,255,0.47)] to-[rgba(255,255,255,0.19)] drop-shadow-[0_0_1.6rem_rgba(0,0,0,0.12)]"
+          >
+            <CheckIcon className="size-8 fill-icon-primary" />
+          </span>
+        )}
+      </button>
+    </li>
+  );
+};

--- a/src/components/common/ListItem/ListItem.tsx
+++ b/src/components/common/ListItem/ListItem.tsx
@@ -20,7 +20,7 @@ export const ListItem = (props: Props) => {
     imageSrc,
     imageAlt = '',
     title,
-    year = '2000',
+    year = 2000,
     publisher = '출판사/저자',
     selected = false,
     className,

--- a/src/components/common/ListItem/index.ts
+++ b/src/components/common/ListItem/index.ts
@@ -1,0 +1,1 @@
+export { ListItem } from './ListItem';

--- a/src/components/common/ListItem/listItemVariants.ts
+++ b/src/components/common/ListItem/listItemVariants.ts
@@ -1,0 +1,16 @@
+import { cva } from 'class-variance-authority';
+
+export const listItemVariants = cva(
+  'flex w-full appearance-none items-center gap-[1.6rem] rounded-[2rem] border-0 px-[1.6rem] py-[1.8rem] text-left',
+  {
+    variants: {
+      selected: {
+        true: 'bg-gray-alpha-50',
+        false: 'bg-transparent',
+      },
+    },
+    defaultVariants: {
+      selected: false,
+    },
+  },
+);

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export * from './Button';
 export * from './Header';
 export * from './Icon';
+export * from './ListItem';


### PR DESCRIPTION
## 📌 PR 제목

[FEAT] ListItem 공통 컴포넌트 추가

---

## 🔗 관련 이슈 (Issue)

- Closes #39

---

## ✅ 작업 내용

- Figma "ListItem book" 디자인 기반 공통 `ListItem` 컴포넌트 신규 구현 (`src/components/common/ListItem/`)
- 책 표지 / 제목 / 연도·출판사 메타 / 선택 시 체크 아이콘 렌더링
- `cva` 기반 `listItemVariants`로 `selected` 상태(배경 토글)와 버튼 리셋 스타일 분리
- `<li><button>` 중첩 구조로 키보드 포커스 등 접근성 확보, 토글 시맨틱은 `aria-pressed`로 표현
- props는 실제 사용하는 항목(`imageSrc`, `imageAlt`, `title`, `year`, `publisher`, `selected`, `className`, `onClick`)만 명시 — 외부 button attr을 통째로 상속받지 않도록 의도적으로 축소
- 메타 라인은 `year`/`publisher`를 분리해 받고 `{year} | {publisher}` 형태로 합쳐 표시
- Storybook 시나리오 추가: `common/ListItem` 하위 `Default` / `Selected` 두 케이스, 시각 확인용 점선 보더 적용
- `src/components/common/index.ts` barrel export 갱신

### 스크린샷

|내용|스크린샷|
|---|---|
|Figma 디자인| <img width="442" height="334" alt="image" src="https://github.com/user-attachments/assets/a5d7251d-922a-4562-b2e4-93f133532180" /> |
|기본| <img width="394" height="145" alt="image" src="https://github.com/user-attachments/assets/4a2a4982-a6cb-4de3-9e44-ebb552d82f8e" /> <br/><li>테두리는 컴포넌트 경계를 표시하기 위해 스토리북에만 적용된 상태입니다!</li> |
|`selected === true`|스토리북에서 SVGR 관련 세팅 에러가 나서 표시되지 않네요.. 추가는 되어 있습니다|

### 참고 사항

- Figma 기준 컴포넌트 이름이 `ListItem`인데, `BookListItem`처럼 바꾸는 게 더 명확할 것 같기는 합니다..
- 같은 맥락에서 책 정보를 모두 함께 리스트 데이터로 전달하는 `BookList` 부모 컴포넌트를 만들어도 될 것 같은데, 그 부분은 나중에도 가능할 것 같아 PR은 마무리합니다.

### ⚠️ 알려진 이슈 (Draft 사유)

- Storybook 환경(`@storybook/nextjs-vite`)에 SVGR 플러그인이 설정되지 않아, `CheckIcon`을 렌더하는 `Selected` 스토리가 "Element type is invalid" 에러로 깨집니다.
- 해결안: `.storybook/main.ts`의 `viteFinal`에 `vite-plugin-svgr` 추가 필요. 별도 후속 PR 또는 본 PR 내 추가 커밋 여부는 리뷰에서 합의 후 처리 예정.

---

## 🖥️ 테스트 방법

1. `pnpm storybook` 실행
2. 사이드바 `common/ListItem` 진입
3. `Default` 스토리에서 비선택 상태(투명 배경, 체크 없음) 확인
4. Controls 패널에서 `title`, `year`, `publisher`, `imageSrc` 값 변경 시 즉시 반영되는지 확인
5. (현재 SVG 이슈로 막혀 있음) `Selected` 스토리에서 선택 상태(`gray-alpha-50` 배경 + 우측 28px 체크 버튼) 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * ListItem 컴포넌트 추가: 이미지 썸네일, 제목, 연도·출판사 메타데이터, 클릭 가능 항목 및 선택 표시(체크 아이콘 포함).

* **Style**
  * 선택 상태를 위한 시각적 스타일 추가(배경 전환 등).

* **Documentation**
  * Storybook 문서 추가: 기본 및 선택된 상태 예제 포함.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->