### PR TITLE
[CHORE] CODEOWNERS 등록

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# 모든 PR에 프론트엔드 팀을 자동 리뷰어로 지정 (PR 작성자는 자동 제외됨)
+* @depromeet/saimsaim-web


### PR DESCRIPTION
## 📌 PR 제목

[CHORE] CODEOWNERS 등록

---

## 🔗 관련 이슈 (Issue)

- Closes #42

---

## ✅ 작업 내용

- 모든 PR에 프론트엔드 팀(@depromeet/saimsaim-web)이 자동으로 리뷰어로 지정되도록 `.github/CODEOWNERS` 파일을 추가했습니다.
- PR 작성자는 GitHub의 기본 동작에 따라 자동으로 리뷰어 대상에서 제외되므로, 매번 수동으로 본인을 빼는 번거로움이 사라집니다.

---

## 🖥️ 테스트 방법

> ⚠️ CODEOWNERS의 자동 리뷰 요청이 실제로 동작하려면 레포 Settings에서 추가 설정이 필요합니다.

1. **Settings → Branches (또는 Rules → Rulesets)** 진입
2. `dev`, `main` 브랜치 보호 규칙에서 **"Require review from Code Owners"** 옵션 활성화
3. `@depromeet/saimsaim-web` 팀이 본 레포에 **Write 이상 권한**으로 추가되어 있는지 확인
4. 새 PR을 하나 올려 본 뒤, PR 작성자를 제외한 팀원이 자동으로 리뷰어로 등록되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 코드 리뷰 프로세스 설정 업데이트: Pull request 자동 할당 정책을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->