### PR TITLE
[CHORE] Slack PR 알림 봇 워크플로우 추가

### DIFF
--- a/.github/workflows/slack-pr-notify.yml
+++ b/.github/workflows/slack-pr-notify.yml
@@ -1,0 +1,113 @@
+name: Notify Slack when PR is opened or ready
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  notify-slack:
+    if: ${{ github.event.action == 'ready_for_review' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send Slack message
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_AVATAR: ${{ github.event.pull_request.user.avatar_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$SLACK_BOT_TOKEN" ] || [ -z "$SLACK_CHANNEL_ID" ]; then
+            echo "Slack 설정이 없습니다. SLACK_BOT_TOKEN과 SLACK_CHANNEL_ID secret을 확인해 주세요."
+            exit 1
+          fi
+
+          payload=$(
+            jq -n \
+              --arg channel "$SLACK_CHANNEL_ID" \
+              --arg pr_url "$PR_URL" \
+              --arg pr_number "$PR_NUMBER" \
+              --arg pr_title "$PR_TITLE" \
+              --arg author "$PR_AUTHOR" \
+              --arg avatar "$PR_AUTHOR_AVATAR" \
+              --arg base "$PR_BASE" \
+              --arg head "$PR_HEAD" \
+              '{
+                channel: $channel,
+                text: "<!here> PR이 생성되었습니다. 리뷰해 주세요!",
+                blocks: [
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: ("<!here> PR이 생성되었습니다. 리뷰해 주세요!\n*<" + $pr_url + "|#" + $pr_number + " " + $pr_title + ">*")
+                    }
+                  },
+                  {
+                    type: "section",
+                    fields: [
+                      {
+                        type: "mrkdwn",
+                        text: ("*작성자*\n" + $author)
+                      },
+                      {
+                        type: "mrkdwn",
+                        text: ("*브랜치*\n`" + $head + "` → `" + $base + "`")
+                      }
+                    ]
+                  },
+                  {
+                    type: "actions",
+                    elements: [
+                      {
+                        type: "button",
+                        text: {
+                          type: "plain_text",
+                          text: "PR 보러가기",
+                          emoji: true
+                        },
+                        url: $pr_url,
+                        style: "primary"
+                      }
+                    ]
+                  },
+                  {
+                    type: "context",
+                    elements: [
+                      {
+                        type: "image",
+                        image_url: $avatar,
+                        alt_text: $author
+                      },
+                      {
+                        type: "mrkdwn",
+                        text: $author
+                      }
+                    ]
+                  }
+                ]
+              }'
+          )
+
+          response=$(curl -fsS --retry 3 -X POST \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-type: application/json" \
+            --data "$payload" \
+            "https://slack.com/api/chat.postMessage")
+
+          echo "Slack API response: $response"
+
+          # ok 필드가 true가 아니면 실패 처리
+          if ! echo "$response" | jq -e '.ok == true' > /dev/null; then
+            echo "Slack 메시지 전송 실패"
+            exit 1
+          fi

--- a/.github/workflows/slack-pr-notify.yml
+++ b/.github/workflows/slack-pr-notify.yml
@@ -3,6 +3,7 @@ name: Notify Slack when PR is opened or ready
 on:
   pull_request_target:
     types: [opened, ready_for_review]
+    branches: [dev]
 
 permissions: {}
 
@@ -98,7 +99,7 @@ jobs:
               }'
           )
 
-          response=$(curl -fsS --retry 3 -X POST \
+          response=$(curl -fsS --connect-timeout 5 --max-time 20 --retry 3 -X POST \
             -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
             -H "Content-type: application/json" \
             --data "$payload" \


### PR DESCRIPTION
## 📌 PR 제목

[CHORE] Slack PR 알림 봇 워크플로우 추가

---

## 🔗 관련 이슈 (Issue)

- Closes #44

---

## ✅ 작업 내용

PR이 열리거나 Draft → Ready for Review로 전환될 때 Slack 채널에 알림을 보내는 GitHub Actions 워크플로우를 추가했습니다.

- `.github/workflows/slack-pr-notify.yml` 추가
- Slack Bot Token 방식으로 `chat.postMessage` API 호출
- Block Kit 메시지: `@here` 멘션 + PR 링크 + 작성자/브랜치 정보 + "PR 보러가기" 버튼

**필요한 GitHub Secrets**
- `SLACK_BOT_TOKEN`: Slack 앱 Bot User OAuth Token (`xoxb-...`)
- `SLACK_CHANNEL_ID`: 알림 받을 채널 ID

Slack 앱에 `chat:write` 스코프가 필요하며, 봇이 해당 채널에 초대되어 있어야 합니다.

---

## 🖥️ 테스트 방법

1. GitHub 레포 Settings → Secrets and variables → Actions에서 위 두 Secret 추가
2. `dev` 브랜치 대상으로 PR 생성 (또는 Draft PR → Ready for Review 전환)
3. Slack 채널에서 알림 메시지 수신 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * PR이 생성되거나 "검토 준비(ready for review)" 상태일 때 dev 브랜치 대상의 팀 Slack 채널로 자동 알림을 전송합니다.
  * 알림에 PR 번호·제목·작성자·기준/대상 브랜치 정보와 인터랙티브 버튼·컨텍스트가 포함됩니다.
  * 전송 유효성 검사를 수행해 실패 시 알림을 재시도하거나 오류로 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->