### PR TITLE
[CHORE] Storybook GitHub Pages 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -1,0 +1,61 @@
+name: Deploy Storybook
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to deploy. Defaults to the selected workflow ref.'
+        required: false
+        type: string
+
+concurrency:
+  group: storybook-gh-pages
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  HUSKY: 0
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook
+        run: pnpm run build-storybook
+
+      - name: Disable Jekyll
+        run: touch storybook-static/.nojekyll
+
+      - name: Deploy Storybook to Pages root
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: storybook-static
+          clean: true
+          clean-exclude: |
+            pr-*
+            pr-*/**
+          force: false
+          attempt-limit: 5

--- a/.github/workflows/storybook-pages-reset.yml
+++ b/.github/workflows/storybook-pages-reset.yml
@@ -1,0 +1,36 @@
+name: Reset Storybook Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type RESET_STORYBOOK_PAGES to remove all Storybook Pages deployments.'
+        required: true
+        type: string
+
+concurrency:
+  group: storybook-gh-pages
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  reset:
+    if: ${{ inputs.confirm == 'RESET_STORYBOOK_PAGES' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create empty Pages directory
+        run: |
+          mkdir empty-pages
+          touch empty-pages/.nojekyll
+
+      - name: Reset gh-pages branch
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: empty-pages
+          clean: true
+          single-commit: true
+

--- a/.github/workflows/storybook-preview-cleanup.yml
+++ b/.github/workflows/storybook-preview-cleanup.yml
@@ -1,0 +1,51 @@
+name: Cleanup Storybook Preview
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+concurrency:
+  group: storybook-gh-pages
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout gh-pages
+        id: checkout-gh-pages
+        uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          ref: gh-pages
+
+      - name: Remove Storybook preview directory
+        if: steps.checkout-gh-pages.outcome == 'success'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          preview_dir="pr-${PR_NUMBER}"
+
+          if [ ! -d "$preview_dir" ]; then
+            echo "No Storybook preview directory found: $preview_dir"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm -r "$preview_dir"
+
+          if git diff --cached --quiet; then
+            echo "No Storybook preview cleanup changes to commit."
+            exit 0
+          fi
+
+          git commit -m "Remove Storybook preview for PR #${PR_NUMBER}"
+          git push origin gh-pages

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -1,0 +1,143 @@
+name: Deploy Storybook Preview
+
+on:
+  pull_request:
+    types: [labeled]
+    branches: [dev]
+
+concurrency:
+  group: storybook-gh-pages
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+env:
+  HUSKY: 0
+
+jobs:
+  deploy-preview:
+    if: >-
+      ${{
+        github.event.label.name == 'storybook preview' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook
+        run: pnpm run build-storybook
+
+      - name: Disable Jekyll
+        run: touch storybook-static/.nojekyll
+
+      - name: Deploy Storybook preview
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: storybook-static
+          target-folder: pr-${{ github.event.pull_request.number }}
+          clean: true
+          force: false
+          attempt-limit: 5
+
+      - name: Comment preview URL
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/pr-${prNumber}/`;
+            const marker = '<!-- storybook-preview-comment -->';
+            const body = `${marker}\nStorybook Preview: ${previewUrl}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const previous = comments.find(
+              (comment) =>
+                comment.user.type === 'Bot' &&
+                comment.body.includes(marker),
+            );
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+      - name: Comment preview failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const marker = '<!-- storybook-preview-comment -->';
+            const body = `${marker}\nStorybook Preview build failed: ${runUrl}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const previous = comments.find(
+              (comment) =>
+                comment.user.type === 'Bot' &&
+                comment.body.includes(marker),
+            );
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });


### PR DESCRIPTION
## 📌 PR 제목

[CHORE] Storybook GitHub Pages 배포 워크플로우 추가

---

## 🔗 관련 이슈 (Issue)

- Closes #62

---

## ✅ 작업 내용

Storybook을 GitHub Pages에 자동 배포하기 위한 4개의 워크플로우를 추가했습니다.
PR 라벨 기반 preview 배포와 정리, 수동 전체 배포·초기화를 모두 지원합니다.

- **storybook-deploy.yml** 추가: `workflow_dispatch`로 수동 트리거 시 Storybook을 GitHub Pages 루트(`gh-pages` 브랜치)에 배포. 기존 PR preview 디렉터리(`pr-*`)는 보존
- **storybook-preview.yml** 추가: `dev` 대상 PR에 `storybook preview` 라벨 추가 시 `pr-{PR번호}` 디렉터리에 Storybook preview 빌드·배포하고 PR에 미리보기 URL 코멘트 자동 등록 (중복 코멘트 시 업데이트)
- **storybook-preview-cleanup.yml** 추가: `dev` 대상 PR이 닫힐 때 해당 `pr-{PR번호}` preview 디렉터리를 `gh-pages` 브랜치에서 자동 삭제
- **storybook-pages-reset.yml** 추가: `workflow_dispatch`로 `RESET_STORYBOOK_PAGES` 입력 시 GitHub Pages 전체 초기화 (비상용)

모든 워크플로우는 `storybook-gh-pages` concurrency group으로 순차 실행을 보장합니다.

---

## 🖥️ 테스트 방법

1. `dev` 대상 PR 생성
2. `storybook preview` 라벨 추가
3. Actions 탭에서 **Deploy Storybook Preview** 워크플로우 실행 확인
4. PR 코멘트에 preview URL(`/pr-{번호}/`) 자동 등록 확인
5. PR 닫기 후 **Cleanup Storybook Preview** 워크플로우 실행 및 `gh-pages` 브랜치에서 preview 디렉터리 삭제 확인
6. Actions 탭에서 **Deploy Storybook** 수동 실행 후 GitHub Pages 루트 배포 확인
