### PR TITLE
[FEAT] 공통 컴포넌트 스토리북 추가 및 위치 정리

### DIFF
--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -12,10 +12,13 @@ concurrency:
 permissions:
   contents: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 env:
   HUSKY: 0
+  # Storybook 빌드 시 next.config.ts 로드를 통과시키기 위한 placeholder.
+  # Storybook은 Next의 API rewrite를 사용하지 않으므로 실제 프록시 대상 URL이 아니어도 무방.
+  API_PROXY_TARGET: http://localhost
 
 jobs:
   deploy-preview:
@@ -28,17 +31,17 @@ jobs:
 
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -63,8 +66,9 @@ jobs:
           attempt-limit: 5
 
       - name: Comment preview URL
+        id: comment-preview-url
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -72,39 +76,43 @@ jobs:
             const marker = '<!-- storybook-preview-comment -->';
             const body = `${marker}\nStorybook Preview: ${previewUrl}`;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 100,
-            });
-
-            const previous = comments.find(
-              (comment) =>
-                comment.user.type === 'Bot' &&
-                comment.body.includes(marker),
-            );
-
-            if (previous) {
-              await github.rest.issues.updateComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                comment_id: previous.id,
+                issue_number: prNumber,
+                per_page: 100,
+              });
+
+              const previous = comments.find(
+                (comment) =>
+                  comment.user.type === 'Bot' &&
+                  comment.body.includes(marker),
+              );
+
+              if (previous) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: previous.id,
+                  body,
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
                 body,
               });
-              return;
+            } catch (error) {
+              core.warning(`Failed to write Storybook preview comment: ${error.message}`);
             }
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body,
-            });
-
       - name: Comment preview failure
-        if: failure()
-        uses: actions/github-script@v7
+        if: failure() && steps.comment-preview-url.outcome == 'skipped'
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -112,32 +120,36 @@ jobs:
             const marker = '<!-- storybook-preview-comment -->';
             const body = `${marker}\nStorybook Preview build failed: ${runUrl}`;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 100,
-            });
-
-            const previous = comments.find(
-              (comment) =>
-                comment.user.type === 'Bot' &&
-                comment.body.includes(marker),
-            );
-
-            if (previous) {
-              await github.rest.issues.updateComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                comment_id: previous.id,
+                issue_number: prNumber,
+                per_page: 100,
+              });
+
+              const previous = comments.find(
+                (comment) =>
+                  comment.user.type === 'Bot' &&
+                  comment.body.includes(marker),
+              );
+
+              if (previous) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: previous.id,
+                  body,
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
                 body,
               });
-              return;
+            } catch (error) {
+              core.warning(`Failed to write Storybook preview failure comment: ${error.message}`);
             }
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body,
-            });

--- a/src/components/common/BottomSheet/BottomSheet.stories.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.stories.tsx
@@ -1,0 +1,78 @@
+import { type Meta, type StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+import { fn } from 'storybook/test';
+import { ListItem } from '@/components';
+import { BottomSheet } from './BottomSheet';
+
+const DEMO_BOOKS = [
+  { title: '해리포터와 마법사의 돌 1', selected: true },
+  { title: '해리포터와 마법사의 돌 2', selected: false },
+  { title: '해리포터와 비밀의 방', selected: false },
+  { title: '해리포터와 아즈카반의 죄수', selected: false },
+];
+
+const BookList = () => (
+  <ul className="flex flex-col px-4 pb-[2.4rem]">
+    {DEMO_BOOKS.map(({ title, selected }) => (
+      <ListItem
+        key={title}
+        imageSrc="https://placehold.co/50x73"
+        imageAlt={`${title} 표지`}
+        title={title}
+        year={2024}
+        publisher="문학수첩"
+        selected={selected}
+      />
+    ))}
+  </ul>
+);
+
+const meta = {
+  title: 'Common/BottomSheet',
+  component: BottomSheet,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  args: {
+    open: false,
+    children: null,
+    onClose: fn(),
+    onMaxHeightTransitionEnd: fn(),
+  },
+} satisfies Meta<typeof BottomSheet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  render: (args) => (
+    <div className="relative h-screen">
+      <BottomSheet {...args} open>
+        <BookList />
+      </BottomSheet>
+    </div>
+  ),
+};
+
+const InteractiveStory = (args: React.ComponentProps<typeof BottomSheet>) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <button
+        type="button"
+        className="rounded-2xl bg-gray-900 px-[1.6rem] py-[0.8rem] text-white"
+        onClick={() => setOpen(true)}
+      >
+        바텀시트 열기
+      </button>
+      <BottomSheet {...args} open={open} onClose={() => setOpen(false)}>
+        <BookList />
+      </BottomSheet>
+    </div>
+  );
+};
+
+export const Interactive: Story = {
+  render: (args) => <InteractiveStory {...args} />,
+};

--- a/src/components/common/BottomSheet/BottomSheet.stories.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/nextjs-vite';
-import { useState } from 'react';
+import { type ComponentProps, useState } from 'react';
 import { fn } from 'storybook/test';
 import { ListItem } from '@/components';
 import { BottomSheet } from './BottomSheet';
@@ -55,7 +55,7 @@ export const Open: Story = {
   ),
 };
 
-const InteractiveStory = (args: React.ComponentProps<typeof BottomSheet>) => {
+const InteractiveStory = (args: ComponentProps<typeof BottomSheet>) => {
   const [open, setOpen] = useState(false);
   return (
     <div className="flex h-screen items-center justify-center">

--- a/src/components/common/ChatCard/ChatCard.stories.tsx
+++ b/src/components/common/ChatCard/ChatCard.stories.tsx
@@ -1,0 +1,103 @@
+import { type Meta, type StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+import { ChatCard } from './ChatCard';
+
+const meta = {
+  title: 'Common/ChatCard',
+  component: ChatCard,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="w-[37.5rem]">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    color: {
+      control: 'select',
+      options: ['teal', 'magenta', 'yellow', 'sky', 'green', 'purple', 'blue'],
+      description: '카드 색상',
+    },
+    status: {
+      control: 'select',
+      options: ['default', 'loading', 'error'],
+      description: '카드 상태',
+    },
+    bookmarked: {
+      control: 'boolean',
+      description: '북마크 여부',
+    },
+  },
+  args: {
+    color: 'teal',
+    status: 'default',
+    bookmarked: false,
+    date: '25.10.10',
+    summary: '대화한 내용 간단 요약 어쩌구 저쩌구',
+    onRefresh: fn(),
+  },
+} satisfies Meta<typeof ChatCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Bookmarked: Story = {
+  name: 'Default / Bookmarked',
+  args: {
+    bookmarked: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    status: 'loading',
+  },
+};
+
+export const ErrorCard: Story = {
+  name: 'Error',
+  args: {
+    status: 'error',
+  },
+};
+
+export const ColorTeal: Story = {
+  name: 'Color / Teal',
+  args: { color: 'teal' },
+};
+
+export const ColorMagenta: Story = {
+  name: 'Color / Magenta',
+  args: { color: 'magenta' },
+};
+
+export const ColorYellow: Story = {
+  name: 'Color / Yellow',
+  args: { color: 'yellow' },
+};
+
+export const ColorSky: Story = {
+  name: 'Color / Sky',
+  args: { color: 'sky' },
+};
+
+export const ColorGreen: Story = {
+  name: 'Color / Green',
+  args: { color: 'green' },
+};
+
+export const ColorPurple: Story = {
+  name: 'Color / Purple',
+  args: { color: 'purple' },
+};
+
+export const ColorBlue: Story = {
+  name: 'Color / Blue',
+  args: { color: 'blue' },
+};

--- a/src/components/common/Loading/Loading.stories.tsx
+++ b/src/components/common/Loading/Loading.stories.tsx
@@ -1,0 +1,23 @@
+import { type Meta, type StoryObj } from '@storybook/nextjs-vite';
+import { Loading } from './index';
+
+const meta = {
+  title: 'Common/Loading',
+  component: Loading,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="h-[20rem] w-[37.5rem]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/common/Textfield/TextfieldChat.stories.tsx
+++ b/src/components/common/Textfield/TextfieldChat.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { type Meta, type StoryObj } from '@storybook/nextjs-vite';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 import { TextfieldChat } from '@/components';
@@ -44,19 +44,21 @@ export const Default: Story = {
   },
 };
 
+const WritingStory = (args: React.ComponentProps<typeof TextfieldChat>) => {
+  const [value, setValue] = useState('');
+  return (
+    <TextfieldChat
+      {...args}
+      status={CHAT_STATUS.DEFAULT}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
 export const Writing: Story = {
   name: '입력 중',
-  render: (args) => {
-    const [value, setValue] = useState('');
-    return (
-      <TextfieldChat
-        {...args}
-        status={CHAT_STATUS.DEFAULT}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
-    );
-  },
+  render: (args) => <WritingStory {...args} />,
   args: {
     bgVariant: CHAT_BG_VARIANT.GRAY,
     placeholder: CHAT_PLACEHOLDER[CHAT_STATUS.DEFAULT],

--- a/src/components/common/Textfield/TextfieldChat.stories.tsx
+++ b/src/components/common/Textfield/TextfieldChat.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/nextjs-vite';
-import { useState } from 'react';
+import { type ComponentProps, useState } from 'react';
 import { fn } from 'storybook/test';
 import { TextfieldChat } from '@/components';
 import { CHAT_BG_VARIANT, CHAT_PLACEHOLDER, CHAT_STATUS } from '@/constants';
@@ -44,7 +44,7 @@ export const Default: Story = {
   },
 };
 
-const WritingStory = (args: React.ComponentProps<typeof TextfieldChat>) => {
+const WritingStory = (args: ComponentProps<typeof TextfieldChat>) => {
   const [value, setValue] = useState('');
   return (
     <TextfieldChat

--- a/src/components/common/Textfield/TextfieldSearch.stories.tsx
+++ b/src/components/common/Textfield/TextfieldSearch.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/nextjs-vite';
-import { useState } from 'react';
+import { type ComponentProps, useState } from 'react';
 import { fn } from 'storybook/test';
 import { TextfieldSearch } from '@/components';
 
@@ -25,7 +25,7 @@ export const Default: Story = {
   name: '기본 (빈 상태)',
 };
 
-const WritingStory = (args: React.ComponentProps<typeof TextfieldSearch>) => {
+const WritingStory = (args: ComponentProps<typeof TextfieldSearch>) => {
   const [value, setValue] = useState('');
   return <TextfieldSearch {...args} value={value} onChange={(e) => setValue(e.target.value)} />;
 };

--- a/src/components/common/Textfield/TextfieldSearch.stories.tsx
+++ b/src/components/common/Textfield/TextfieldSearch.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { type Meta, type StoryObj } from '@storybook/nextjs-vite';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 import { TextfieldSearch } from '@/components';
@@ -25,12 +25,14 @@ export const Default: Story = {
   name: '기본 (빈 상태)',
 };
 
+const WritingStory = (args: React.ComponentProps<typeof TextfieldSearch>) => {
+  const [value, setValue] = useState('');
+  return <TextfieldSearch {...args} value={value} onChange={(e) => setValue(e.target.value)} />;
+};
+
 export const Writing: Story = {
   name: '입력 중',
-  render: (args) => {
-    const [value, setValue] = useState('');
-    return <TextfieldSearch {...args} value={value} onChange={(e) => setValue(e.target.value)} />;
-  },
+  render: (args) => <WritingStory {...args} />,
 };
 
 export const Filled: Story = {


### PR DESCRIPTION
## 📌 PR 제목

[FEAT] 공통 컴포넌트 스토리북 추가 및 위치 정리

---

## 🔗 관련 이슈 (Issue)

- Closes #67

---

## ✅ 작업 내용

스토리북이 없던 공통 컴포넌트 4종에 스토리북을 추가하고, 잘못된 위치에 있던 Textfield 스토리 파일을 각 컴포넌트 폴더로 이동했습니다.
각 컴포넌트의 스토리 케이스는 Figma MCP로 디자인 노드를 조회하여 Figma에 정의된 Variant 기준으로만 작성했습니다.

**추가된 스토리북**
- BottomSheet: Open(Figma 기준 단일 케이스) + Interactive(Portal 특성상 토글 스토리 추가)
- ChatCard: color 7종 x status 3종(Default/Loading/Error) + Bookmarked 케이스
- Loading: Default 단일 케이스(Figma의 property1 6종은 CSS 애니메이션 프레임 표현)

**이동 및 컨벤션 정리**
- src/stories/TextfieldChat.stories.tsx → src/components/common/Textfield/TextfieldChat.stories.tsx
- src/stories/TextfieldSearch.stories.tsx → src/components/common/Textfield/TextfieldSearch.stories.tsx
- import type { ... } 구문을 import { type ... } 인라인 형식으로 수정
- render 함수 내 useState 직접 사용을 별도 컴포넌트로 분리

---

## 🖥️ 테스트 방법

1. pnpm storybook 실행
2. Common 카테고리에서 아래 컴포넌트 확인
   - BottomSheet: Open 스토리에서 바텀시트 렌더, Interactive에서 토글 동작 확인
   - ChatCard: color / status / bookmark Variant 전환 확인
   - Loading: Default 스토리에서 dot 애니메이션 확인
   - Textfield/TextfieldChat, Textfield/TextfieldSearch: 기존과 동일하게 표시되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * BottomSheet, ChatCard, Loading 컴포넌트의 Storybook 스토리 추가 및 다양한 변형(북마크/로딩/오류/색상) 포함
* **리팩토링**
  * Textfield 관련 스토리의 타입 임포트 스타일 개선 및 상태 관리 로직을 별도 헬퍼 컴포넌트로 분리
* **잡무**
  * Storybook 미리보기 워크플로우 권한/액션 버전 및 PR 코멘트 로직 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team4-web/pull/72)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->