### PR TITLE
[BUG] pnpm, amplify 호환성 버그 수정

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,8 +3,9 @@ frontend:
   phases:
     preBuild:
       commands:
-        - npm install -g pnpm
-        - pnpm install
+        - corepack enable
+        - corepack prepare pnpm@10.33.4 --activate
+        - pnpm install --frozen-lockfile
     build:
       commands:
         - pnpm run build
@@ -12,3 +13,7 @@ frontend:
     baseDirectory: .next
     files:
       - "**/*"
+  cache:
+    paths:
+      - .next/cache/**/*
+      - node_modules/**/*

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "readwith",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.33.4",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp",
+      "unrs-resolver"
+    ]
+  },
   "scripts": {
     "dev": "next dev",
     "dev:host": "next dev -H 0.0.0.0",


### PR DESCRIPTION
## 📌 PR 제목

[BUG] pnpm, amplify 호환성 버그 수정

## ✅ 작업 내용

pnpm 10에서 esbuild, sharp, unrs-resolver 빌드 스크립트가 기본 차단되어 Amplify 배포 실패하는 문제 수정