### PR TITLE
[FIX] pnpm 빌드 오류 및 API 엔드포인트 수정

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 const API_PROXY_TARGET = process.env.API_PROXY_TARGET!;
 
-export const middleware = async (request: NextRequest) => {
+export const proxy = async (request: NextRequest) => {
   const userSession = request.cookies.get('user_session');
 
   // user_session 쿠키가 없으면 신규 세션 생성


### PR DESCRIPTION
## 변경 사항

### 1. pnpm `ERR_PNPM_IGNORED_BUILDS` 빌드 오류 수정
pnpm 10에서 `esbuild`, `sharp`, `unrs-resolver`의 빌드 스크립트가 기본 차단되어 Amplify 배포 실패하는 문제 수정

- `package.json`에 `pnpm.onlyBuiltDependencies` 허용 목록 추가
- `amplify.yml` pnpm 버전 고정 및 캐시 설정 추가

### 2. `middleware.ts` → `proxy.ts` 마이그레이션
Next.js 16에서 `middleware` 파일 컨벤션이 deprecated되고 `proxy`로 변경됨

### 3. `NEXT_PUBLIC_API_URL` 수정 (Amplify 콘솔 환경변수도 별도 변경 필요)
프로덕션에서 절대경로(`https://api.readum.kr/api/v1`) 사용 시 브라우저가 직접 외부 API를 호출해 CORS 오류 발생

→ 개발환경과 동일하게 `/api/v1`(상대경로)로 변경하여 Next.js rewrite 프록시를 통해 라우팅

> **주의**: Amplify 콘솔 환경변수에서 `NEXT_PUBLIC_API_URL` 값도 `/api/v1`로 변경 필요

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기술 개선**
  * 내부 세션 처리 로직이 재구성되었습니다. 사용자에게 보이는 기능과 동작은 모두 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->