### PR TITLE
[FEAT] ChatCard 색상 순서 배열 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1761,6 +1760,7 @@
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1849,6 +1849,28 @@
       },
       "peerDependencies": {
         "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -4087,7 +4109,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4495,7 +4516,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
       "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.100.9"
       },
@@ -4530,6 +4550,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4550,6 +4571,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4611,7 +4633,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4717,7 +4740,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4728,7 +4750,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4795,7 +4816,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -5321,7 +5341,6 @@
       "integrity": "sha512-iCDGI8c4yg+xmjUg2VsygdAUSIIB4x5Rht/P68OXy1hPELKXHDkzh87lkuTcdYmemRChDkEpB426MmDjzC0ziA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@blazediff/core": "1.9.1",
         "@vitest/mocker": "4.1.5",
@@ -5345,7 +5364,6 @@
       "integrity": "sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -5370,7 +5388,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -5520,7 +5537,6 @@
       "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
@@ -5583,7 +5599,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5640,6 +5655,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6054,7 +6070,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6698,6 +6713,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6730,7 +6746,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -7083,7 +7100,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7148,7 +7164,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7334,7 +7349,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9440,6 +9454,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10163,7 +10178,6 @@
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.59.1"
       },
@@ -10255,7 +10269,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10272,6 +10285,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10287,6 +10301,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10299,7 +10314,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -10349,7 +10365,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10426,7 +10441,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11160,7 +11174,6 @@
       "integrity": "sha512-vbSz7g/1rGMC1uAULqMZjALkIuLu2QABqfhRYhyr/11kzyesi+vAmwyJLukZP1FfecxGOgMwOh6GS0YsGpHAvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -11615,7 +11628,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11839,7 +11851,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12063,7 +12074,6 @@
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -12074,7 +12084,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12243,7 +12252,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -12643,7 +12651,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/common/ChatCard/chatCardVariants.ts
+++ b/src/components/common/ChatCard/chatCardVariants.ts
@@ -60,3 +60,13 @@ export const chatCardIconColor: Record<ChatCardColor, string> = {
   purple: 'fill-sub-purple',
   blue: 'fill-sub-blue',
 };
+
+export const CHAT_CARD_COLOR_SEQUENCE: readonly ChatCardColor[] = [
+  CHAT_CARD_COLOR.TEAL,
+  CHAT_CARD_COLOR.GREEN,
+  CHAT_CARD_COLOR.PURPLE,
+  CHAT_CARD_COLOR.YELLOW,
+  CHAT_CARD_COLOR.MAGENTA,
+  CHAT_CARD_COLOR.SKY,
+  CHAT_CARD_COLOR.BLUE,
+];

--- a/src/components/common/ChatCard/index.ts
+++ b/src/components/common/ChatCard/index.ts
@@ -1,6 +1,7 @@
 export { ChatCard, type ChatCardProps } from './ChatCard';
 export {
   CHAT_CARD_COLOR,
+  CHAT_CARD_COLOR_SEQUENCE,
   CHAT_CARD_STATUS,
   chatCardBackgroundColor,
   type ChatCardColor,

--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -1,7 +1,31 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { CHAT_CARD_COLOR, CHAT_CARD_STATUS, ChatCard, Header, HEADER_VARIANT } from '@/components';
+import {
+  CHAT_CARD_COLOR_SEQUENCE,
+  CHAT_CARD_STATUS,
+  ChatCard,
+  Header,
+  HEADER_VARIANT,
+  type ChatCardStatus,
+} from '@/components';
+
+type MockRecord = {
+  id: number;
+  date: string;
+  summary?: string;
+  status?: ChatCardStatus;
+  bookmarked?: boolean;
+};
+
+const MOCK_RECORDS: MockRecord[] = [
+  { id: 1, date: '25.10.10', summary: '대화한 내용 간단 요약 어쩌구 저쩌...' },
+  { id: 2, date: '25.10.10', summary: '대화한 내용 간단 요약 어쩌구 저쩌...' },
+  { id: 3, date: '25.10.10', summary: '대화한 내용 간단 요약 어쩌구 저쩌...' },
+  { id: 4, date: '25.10.10', summary: '대화한 내용 간단 요약 어쩌구 저쩌...' },
+  { id: 5, date: '25.10.10', status: CHAT_CARD_STATUS.LOADING },
+  { id: 6, date: '25.10.10', summary: '대화한 내용 간단 요약 어쩌구 저쩌...', bookmarked: true },
+];
 
 export const RecordsBody = () => {
   const containerRef = useRef<HTMLOListElement>(null);
@@ -15,59 +39,18 @@ export const RecordsBody = () => {
     <main className="relative flex-1 flex flex-col bg-background-primary-base overflow-y-hidden">
       <Header variant={HEADER_VARIANT.HOME} className="absolute top-0 z-10" />
       <div className="flex-1" />
-      <ol
-        ref={containerRef}
-        className="list-none relative flex flex-col overflow-y-auto py-[6.4rem]"
-      >
-        <li className="mb-[-6.4rem]">
-          <ChatCard
-            color={CHAT_CARD_COLOR.MAGENTA}
-            status={CHAT_CARD_STATUS.DEFAULT}
-            date="25.10.10"
-            summary="대화한 내용 간단 요약 어쩌구 저쩌..."
-          />
-        </li>
-        <li className="mb-[-6.4rem]">
-          <ChatCard
-            color={CHAT_CARD_COLOR.MAGENTA}
-            status={CHAT_CARD_STATUS.DEFAULT}
-            date="25.10.10"
-            summary="대화한 내용 간단 요약 어쩌구 저쩌..."
-          />
-        </li>
-        <li className="mb-[-6.4rem]">
-          <ChatCard
-            color={CHAT_CARD_COLOR.YELLOW}
-            status={CHAT_CARD_STATUS.DEFAULT}
-            date="25.10.10"
-            summary="대화한 내용 간단 요약 어쩌구 저쩌..."
-          />
-        </li>
-        <li className="mb-[-6.4rem]">
-          <ChatCard
-            color={CHAT_CARD_COLOR.PURPLE}
-            status={CHAT_CARD_STATUS.DEFAULT}
-            date="25.10.10"
-            summary="대화한 내용 간단 요약 어쩌구 저쩌..."
-          />
-        </li>
-        <li className="mb-[-6.4rem]">
-          <ChatCard
-            color={CHAT_CARD_COLOR.GREEN}
-            status={CHAT_CARD_STATUS.LOADING}
-            date="25.10.10"
-            summary="대화한 내용 간단 요약 어쩌구 저쩌..."
-          />
-        </li>
-        <li className="mb-[-6.4rem]">
-          <ChatCard
-            color={CHAT_CARD_COLOR.TEAL}
-            status={CHAT_CARD_STATUS.DEFAULT}
-            date="25.10.10"
-            summary="대화한 내용 간단 요약 어쩌구 저쩌..."
-            bookmarked
-          />
-        </li>
+      <ol ref={containerRef} className="list-none relative flex flex-col overflow-y-auto py-[6.4rem]">
+        {MOCK_RECORDS.map((record, index) => (
+          <li key={record.id} className="mb-[-6.4rem]">
+            <ChatCard
+              color={CHAT_CARD_COLOR_SEQUENCE[(MOCK_RECORDS.length - 1 - index) % CHAT_CARD_COLOR_SEQUENCE.length]}
+              status={record.status}
+              date={record.date}
+              summary={record.summary}
+              bookmarked={record.bookmarked}
+            />
+          </li>
+        ))}
       </ol>
     </main>
   );


### PR DESCRIPTION
## 📌 PR 제목

[FEAT] ChatCard 색상 순서 배열 추가 및 목업 데이터 적용

---

## 🔗 관련 이슈 (Issue)

- Refs #56

---

## ✅ 작업 내용

ChatCard가 생성되는 순서에 따라 색상이 고정된 시퀀스로 적용되도록 구현했습니다.

- chatCardVariants.ts에 CHAT_CARD_COLOR_SEQUENCE 상수 추가 (teal → green → purple → yellow → magenta → sky → blue 순서, 7개 초과 시 반복)
- 가장 최신 카드(화면 맨 아래)가 teal(#D5EFECCC)을 받도록 끝에서부터 역순으로 색상 인덱스 계산
- RecordsBody를 하드코딩된 JSX에서 MOCK_RECORDS 배열 매핑 방식으로 리팩토링 (API 연동 시 교체 용이하도록)

**타입 변경 사항**
- CHAT_CARD_COLOR_SEQUENCE (readonly ChatCardColor[]) 신규 export

---

## 🖥️ 테스트 방법

1. 홈 화면(기록 있는 경우) 진입
2. ChatCard가 아래에서부터 teal → green → purple ... 순서로 쌓이는지 확인
3. 카드를 7개 이상으로 늘렸을 때 색상이 동일 순서로 반복되는지 확인
---

피그마에 색상 순서대로 변경했습니다! 

<img width="407" height="685" alt="스크린샷 2026-05-07 오후 10 53 29" src="https://github.com/user-attachments/assets/9c261343-ad1b-4841-ba23-4a4ff3d8287e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 채팅 카드가 동적으로 렌더링되도록 변경되었습니다.
  * 카드 색상이 자동으로 순환하여 할당되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->