### PR TITLE
[FIX] Amplify 빈 화면 수정 — output standalone 제거 및 세션 null 폴백 개선

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -12,7 +12,7 @@ frontend:
   artifacts:
     baseDirectory: .next
     files:
-      - "**/*"
+      - '**/*'
   cache:
     paths:
       - .next/cache/**/*

--- a/next.config.ts
+++ b/next.config.ts
@@ -50,8 +50,6 @@ const nextConfig: NextConfig = {
 
     return config;
   },
-
-  output: 'standalone',
 };
 
 export default nextConfig;

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+
+export const GET = async () => {
+  const apiProxyTarget = process.env.API_PROXY_TARGET;
+  const nextPublicApiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  let apiReachable = false;
+  let apiStatus: number | null = null;
+  let apiError: string | null = null;
+
+  if (apiProxyTarget) {
+    try {
+      const res = await fetch(`${apiProxyTarget}/api/v1/users/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      apiStatus = res.status;
+      apiReachable = true;
+    } catch (e) {
+      apiError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  return NextResponse.json({
+    env: {
+      API_PROXY_TARGET: apiProxyTarget ?? '(not set)',
+      NEXT_PUBLIC_API_URL: nextPublicApiUrl ?? '(not set)',
+      NODE_ENV: process.env.NODE_ENV,
+    },
+    api: {
+      reachable: apiReachable,
+      status: apiStatus,
+      error: apiError,
+    },
+  });
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,8 @@ import localFont from 'next/font/local';
 import Image from 'next/image';
 import { type ReactNode } from 'react';
 import { Background } from '@/assets';
-import { PageTransition, QueryProvider } from '@/providers';
 import { ToastContainer } from '@/components';
+import { PageTransition, QueryProvider } from '@/providers';
 
 const suit = localFont({
   src: '../../public/fonts/SUIT-Variable.woff2',
@@ -45,7 +45,7 @@ const RootLayout = (props: Props): React.ReactElement => {
               <PageTransition>{children}</PageTransition>
             </QueryProvider>
           </div>
-        
+
           <ToastContainer />
         </main>
       </body>

--- a/src/components/pages/Main/Container.tsx
+++ b/src/components/pages/Main/Container.tsx
@@ -11,9 +11,21 @@ type Props = {
 };
 
 export const MainContainer = ({ session }: Props) => {
-  // 1. 세션 데이터 없음 — API 호출 실패 또는 첫 렌더 race condition 폴백
+  // 1. 세션 데이터 없음 — API 호출 실패: 온보딩 환영 화면 노출
   if (session === null) {
-    return null;
+    return (
+      <div className="flex min-h-dvh flex-col items-center justify-center gap-[2.4rem] px-[2.4rem]">
+        <div className="flex flex-col items-center gap-[0.8rem]">
+          <p className="headline2-extrabold text-center tracking-[-0.06rem] text-text-primary">
+            Readum에 오신 걸 환영해요
+          </p>
+          <p className="body1-medium text-center tracking-[-0.048rem] text-text-caption">
+            온보딩을 건너뛰고 바로 시작할 수 있어요
+          </p>
+        </div>
+        <OnboardingSkipButton />
+      </div>
+    );
   }
 
   // 2. 온보딩 미완료

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { type ReactNode, useState } from 'react';
 
 type Props = {
@@ -24,7 +23,7 @@ export const QueryProvider = ({ children }: Props) => {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
-      <ReactQueryDevtools initialIsOpen={false} />
+      {/* <ReactQueryDevtools initialIsOpen={false} /> */}
     </QueryClientProvider>
   );
 };


### PR DESCRIPTION
## Summary

- `next.config.ts`에서 `output: 'standalone'` 제거 — Amplify Gen 1은 자체 compute layer를 써서 `next start`를 실행하므로 Docker 전용인 standalone output과 호환되지 않음. 이로 인해 `proxy.ts`(세션 생성)가 실행되지 않고 빈 화면이 발생했음
- `MainContainer`: `session === null` 시 `return null` → 온보딩 환영 화면 표시로 변경. API 세션 생성 실패 시에도 사용자가 빈 화면 대신 의미 있는 UI를 볼 수 있도록 개선
- `QueryProvider`: production 환경에서 불필요한 `ReactQueryDevtools` 제거
- `src/app/api/health/route.ts` 추가: Amplify 배포 후 `/api/health`에 접근하면 env vars 설정 여부 및 `api.readum.kr` 도달 가능 여부를 확인할 수 있는 진단용 엔드포인트

## Test plan

- [ ] `pnpm build`가 로컬에서 에러 없이 완료되는지 확인
- [ ] Amplify 배포 후 `https://dev.readum.kr` 접속 시 빈 화면이 아닌 화면이 뜨는지 확인
- [ ] Amplify 배포 후 `https://dev.readum.kr/api/health` 접속해서 `api.reachable: true` 및 `API_PROXY_TARGET` 값 확인


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 상태 확인 엔드포인트 추가

* **개선사항**
  * 초기화 중 온보딩 화면 표시
  * SVG 임포트 처리 최적화
  * 빌드 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->