### PR TITLE
[FIX]Server Action 500 에러 및 httpBase 빈 응답 처리

### DIFF
--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -3,8 +3,16 @@
 import { revalidatePath } from 'next/cache';
 import { completeOnboarding } from '@/lib';
 
+type ActionResult = { success: true } | { success: false; message: string };
+
 /* 온보딩 완료 처리 서버 액션 */
-export const completeOnboardingAction = async () => {
-  await completeOnboarding();
-  revalidatePath('/');
+export const completeOnboardingAction = async (): Promise<ActionResult> => {
+  try {
+    await completeOnboarding();
+    revalidatePath('/');
+    return { success: true };
+  } catch (error) {
+    console.error('[action] completeOnboarding 실패:', error);
+    return { success: false, message: error instanceof Error ? error.message : 'Unknown error' };
+  }
 };

--- a/src/components/pages/Main/OnboardingSkipButton.tsx
+++ b/src/components/pages/Main/OnboardingSkipButton.tsx
@@ -10,8 +10,10 @@ export const OnboardingSkipButton = () => {
 
   const handleSkip = () => {
     startTransition(async () => {
-      await completeOnboardingAction();
-      router.refresh();
+      const result = await completeOnboardingAction();
+      if (result.success) {
+        router.refresh();
+      }
     });
   };
 

--- a/src/lib/api/http/httpBase.ts
+++ b/src/lib/api/http/httpBase.ts
@@ -90,12 +90,14 @@ export const httpBase = async <T>(url: string, options: ApiRequestInit = {}): Pr
     return (await res.blob()) as T;
   }
 
+  // 204 No Content 또는 응답 본문이 없는 경우
+  if (res.status === 204 || res.headers.get('content-length') === '0') {
+    return undefined as T;
+  }
+
   const contentType = res.headers.get('content-type') ?? '';
   if (!contentType.includes('application/json')) {
-    throw new HttpError({
-      message: 'Invalid API response format',
-      status: res.status || 502,
-    });
+    return undefined as T;
   }
 
   try {


### PR DESCRIPTION
## Summary

- `completeOnboardingAction`: try-catch 추가 — API 실패 시 Next.js 500 대신 `{ success: false }` 반환
- `httpBase`: 204 No Content 또는 non-JSON 응답 시 throw 대신 `undefined` 반환하도록 수정 (온보딩 엔드포인트가 JSON 없이 응답할 경우 대비)
- `OnboardingSkipButton`: `result.success` 가 true일 때만 `router.refresh()` 호출

## 재현 흐름

1. 세션은 있으나 `onboardingCompleted: false` 인 유저가 "넘어가기" 클릭
2. `completeOnboardingAction` → `completeOnboarding()` → API 호출 실패 시 `HttpError` throw
3. Server Action에서 catch 없이 throw → Amplify(CloudFront)가 500 반환

## Test plan

- [ ] "넘어가기" 클릭 시 500 에러 없이 정상 처리되는지 확인
- [ ] API 호출 성공 → 페이지 새로고침 후 다음 단계로 이동하는지 확인

Made with [Cursor](https://cursor.com)