### PR TITLE
[FIX] API_PROXY_TARGET Amplify SSR 런타임 env 누락 해결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,11 @@ if (!API_PROXY_TARGET) {
 }
 
 const nextConfig: NextConfig = {
+  // 빌드 타임에 읽은 값을 번들에 bake → Amplify SSR 런타임에서도 process.env로 접근 가능
+  env: {
+    API_PROXY_TARGET,
+  },
+
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## 원인

`.env.production`이 `.gitignore`에 포함되어 Amplify에 배포되지 않음.
Amplify 콘솔 환경변수(`API_PROXY_TARGET`)는 빌드 타임에만 주입되고 SSR 런타임에는 전달되지 않아 `process.env.API_PROXY_TARGET`이 `undefined`.

결과: `proxy.ts` 세션 생성 불가, `httpBase` 서버사이드 API 호출 전부 실패.

## 해결

`next.config.ts`의 `env` 옵션으로 빌드 타임 값을 번들에 bake.

## Test plan

- [ ] `/api/health` → `API_PROXY_TARGET: "https://api.readum.kr"`, `api.reachable: true` 확인
- [ ] 첫 방문 시 `user_session` 쿠키 생성 확인
- [ ] 전체 플로우 정상 동작 확인

Made with [Cursor](https://cursor.com)