### PR TITLE
[FEAT] 채팅 API 연결 및 SSE 스트리밍 구현

### DIFF
--- a/src/app/chat/[sessionId]/page.tsx
+++ b/src/app/chat/[sessionId]/page.tsx
@@ -1,0 +1,13 @@
+import { type Metadata } from 'next';
+import { ChatContainer } from '@/components';
+
+export const generateMetadata = async (): Promise<Metadata> => ({
+  title: 'Readum: AI 대화하기',
+  description: 'Readum:사유하는 독서가인 당신을 위해',
+});
+
+const ChatPage = () => {
+  return <ChatContainer />;
+};
+
+export default ChatPage;

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,13 +1,15 @@
 import { Metadata } from 'next';
 import { ChatContainer } from '@/components';
 
-export async function generateMetadata(): Promise<Metadata> {
+export const generateMetadata = async (): Promise<Metadata> => {
   return {
     title: 'Readum: AI 대화하기',
     description: 'Readum:사유하는 독서가인 당신을 위해',
   };
-}
+};
 
-export default function ChatPage() {
+const page = () => {
   return <ChatContainer />;
-}
+};
+
+export default page;

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -11,6 +11,7 @@ type HeaderProps = React.ComponentProps<'header'> &
   VariantProps<typeof headerVariants> & {
     summarizeActive?: boolean;
     onBack?: () => void;
+    onCta?: () => void;
   };
 
 export const Header = (props: HeaderProps) => {
@@ -19,6 +20,7 @@ export const Header = (props: HeaderProps) => {
     className,
     summarizeActive = false,
     onBack,
+    onCta,
     ...rest
   } = props;
 

--- a/src/components/pages/Chat/Chat.tsx
+++ b/src/components/pages/Chat/Chat.tsx
@@ -7,14 +7,18 @@ import { containerVariants } from './chatVariants';
 type Props = VariantProps<typeof containerVariants> & {
   user?: ChatUser;
   message: string;
+  isStreaming?: boolean;
 };
 
 export const Chat = (props: Props) => {
-  const { user = CHAT_USER.ME, message } = props;
+  const { user = CHAT_USER.ME, message, isStreaming = false } = props;
 
   return (
     <div className={cn(containerVariants({ user }))}>
-      <p className="body2-semibold whitespace-pre-wrap break-words text-text-default">{message}</p>
+      <p className="body2-semibold whitespace-pre-wrap break-words text-text-default">
+        {message}
+        {isStreaming && <span className="animate-pulse">▋</span>}
+      </p>
       {user === CHAT_USER.AI ? <ColorSymbolIcon className="mt-[1.2rem]" /> : null}
     </div>
   );

--- a/src/components/pages/Chat/Chat.tsx
+++ b/src/components/pages/Chat/Chat.tsx
@@ -8,10 +8,11 @@ type Props = VariantProps<typeof containerVariants> & {
   user?: ChatUser;
   message: string;
   isStreaming?: boolean;
+  showIcon?: boolean;
 };
 
 export const Chat = (props: Props) => {
-  const { user = CHAT_USER.ME, message, isStreaming = false } = props;
+  const { user = CHAT_USER.ME, message, isStreaming = false, showIcon = false } = props;
 
   return (
     <div className={cn(containerVariants({ user }))}>
@@ -19,7 +20,7 @@ export const Chat = (props: Props) => {
         {message}
         {isStreaming && <span className="animate-pulse">▋</span>}
       </p>
-      {user === CHAT_USER.AI ? <ColorSymbolIcon className="mt-[1.2rem]" /> : null}
+      {showIcon ? <ColorSymbolIcon className="mt-[1.2rem]" /> : null}
     </div>
   );
 };

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -23,6 +23,7 @@ const Container = () => {
 
   const { isOpen, open, close } = useModal();
 
+  const topRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const [message, setMessage] = useState('');
   const [newChats, setNewChats] = useState<ChatMessage[]>([]);
@@ -30,16 +31,38 @@ const Container = () => {
   const { data: eligibilityData } = useCheckSummaryEligibility(sessionId);
   const canSummarize = eligibilityData?.eligible ?? false;
 
-  const { data: messagesData } = useGetMessages(sessionId);
+  const {
+    data: messagesData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useGetMessages(sessionId);
 
-  const historyChats: ChatMessage[] = (messagesData?.pages ?? [])
-    .flatMap((page) => page.messages)
+  const historyChats: ChatMessage[] = [...(messagesData?.pages ?? [])]
     .reverse()
+    .flatMap((page) => [...page.messages].reverse())
     .map((msg) => ({
       id: msg.id,
       user: msg.role === 'USER' ? CHAT_USER.ME : CHAT_USER.AI,
       message: msg.content,
     }));
+
+  useEffect(() => {
+    const el = topRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingContent, setStreamingContent] = useState('');
@@ -143,6 +166,7 @@ const Container = () => {
 
         <main className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-[2.4rem] pb-48">
           <div className="flex flex-col gap-[2.8rem]">
+            <div ref={topRef} />
             {allChats.map((chat, index) => (
               <Chat
                 key={chat.id}

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -1,27 +1,31 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { Header, HEADER_VARIANT, TextfieldChat } from '@/components';
-import { CHAT_BG_VARIANT, CHAT_USER, ChatMessage } from '@/constants';
+import { CHAT_BG_VARIANT, CHAT_USER, type ChatMessage } from '@/constants';
 import { useModal } from '@/hooks';
-import { chatData } from '@/lib';
+import { chatData, useCheckSummaryEligibility } from '@/lib';
 import { Chat } from './Chat';
 import { Modal } from './Modal';
 
 const Container = () => {
   const router = useRouter();
+  const params = useParams<{ sessionId: string }>();
+  const sessionId = params.sessionId;
+
   const { isOpen, open, close } = useModal();
 
   const bottomRef = useRef<HTMLDivElement>(null);
   const [message, setMessage] = useState('');
   const [chats, setChats] = useState<ChatMessage[]>([]);
 
+  const { data: eligibilityData } = useCheckSummaryEligibility(sessionId);
+  const canSummarize = eligibilityData?.eligible ?? false;
+
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [chats]);
-
-  const canSummarize = chats.filter((chat) => chat.user === CHAT_USER.AI).length >= 2;
 
   const handleSend = () => {
     const trimmedMessage = message.trim();

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Header, HEADER_VARIANT, TextfieldChat } from '@/components';
 import { CHAT_BG_VARIANT, CHAT_USER, type ChatMessage } from '@/constants';
 import { useModal } from '@/hooks';
-import { useCheckSummaryEligibility, useGetMessages, useSendMessage } from '@/lib';
+import { streamChatMessage, useCheckSummaryEligibility, useGetMessages } from '@/lib';
 import { Chat } from './Chat';
 import { Modal } from './Modal';
 
@@ -31,6 +31,7 @@ const Container = () => {
   const canSummarize = eligibilityData?.eligible ?? false;
 
   const { data: messagesData } = useGetMessages(sessionId);
+
   const historyChats: ChatMessage[] = (messagesData?.pages ?? [])
     .flatMap((page) => page.messages)
     .reverse()
@@ -40,7 +41,8 @@ const Container = () => {
       message: msg.content,
     }));
 
-  const { send, isStreaming, streamingContent } = useSendMessage(sessionId);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [streamingContent, setStreamingContent] = useState('');
 
   const allChats = [...historyChats, ...newChats];
 
@@ -61,29 +63,46 @@ const Container = () => {
     };
     setNewChats((prev) => [...prev, userMessage]);
 
-    await send(trimmedMessage, {
-      onDone: (data, accumulated) => {
-        setNewChats((prev) => [
-          ...prev,
-          {
-            id: String(data.messageId),
-            user: CHAT_USER.AI,
-            message: accumulated,
-          },
-        ]);
-      },
-      onError: (data) => {
-        const errorMessage = ERROR_MESSAGES[data.code] ?? '오류가 발생했어요. 다시 시도해주세요.';
-        setNewChats((prev) => [
-          ...prev,
-          {
-            id: crypto.randomUUID(),
-            user: CHAT_USER.AI,
-            message: errorMessage,
-          },
-        ]);
-      },
-    });
+    setIsStreaming(true);
+    setStreamingContent('');
+    let accumulated = '';
+
+    try {
+      await streamChatMessage(sessionId, trimmedMessage, {
+        onToken: (delta) => {
+          accumulated += delta;
+          setStreamingContent(accumulated);
+        },
+        onDone: (data) => {
+          setIsStreaming(false);
+          setStreamingContent('');
+          setNewChats((prev) => [
+            ...prev,
+            {
+              id: String(data.messageId),
+              user: CHAT_USER.AI,
+              message: accumulated,
+            },
+          ]);
+        },
+        onError: (data) => {
+          setIsStreaming(false);
+          setStreamingContent('');
+          const errorMessage = ERROR_MESSAGES[data.code] ?? '오류가 발생했어요. 다시 시도해주세요.';
+          setNewChats((prev) => [
+            ...prev,
+            {
+              id: crypto.randomUUID(),
+              user: CHAT_USER.AI,
+              message: errorMessage,
+            },
+          ]);
+        },
+      });
+    } catch {
+      setIsStreaming(false);
+      setStreamingContent('');
+    }
   };
 
   return (
@@ -103,9 +122,7 @@ const Container = () => {
             {allChats.map((chat) => (
               <Chat key={chat.id} user={chat.user} message={chat.message} />
             ))}
-            {isStreaming && streamingContent && (
-              <Chat user={CHAT_USER.AI} message={streamingContent} />
-            )}
+            {isStreaming && <Chat user={CHAT_USER.AI} message={streamingContent} isStreaming />}
             <div ref={bottomRef} />
           </div>
         </main>

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -45,6 +45,10 @@ const Container = () => {
   const [streamingContent, setStreamingContent] = useState('');
 
   const allChats = [...historyChats, ...newChats];
+  const lastAIIndex = allChats.reduce(
+    (last, chat, i) => (chat.user === CHAT_USER.AI ? i : last),
+    -1,
+  );
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -120,10 +124,17 @@ const Container = () => {
 
         <main className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-[2.4rem] pb-48">
           <div className="flex flex-col gap-[2.8rem]">
-            {allChats.map((chat) => (
-              <Chat key={chat.id} user={chat.user} message={chat.message} />
+            {allChats.map((chat, index) => (
+              <Chat
+                key={chat.id}
+                user={chat.user}
+                message={chat.message}
+                showIcon={!isStreaming && index === lastAIIndex}
+              />
             ))}
-            {isStreaming && <Chat user={CHAT_USER.AI} message={streamingContent} isStreaming />}
+            {isStreaming && (
+              <Chat user={CHAT_USER.AI} message={streamingContent} isStreaming showIcon />
+            )}
             <div ref={bottomRef} />
           </div>
         </main>

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -70,6 +70,7 @@ const Container = () => {
     setIsStreaming(true);
     setStreamingContent('');
     let accumulated = '';
+    let streamFinished = false;
 
     try {
       await streamChatMessage(sessionId, trimmedMessage, {
@@ -79,6 +80,7 @@ const Container = () => {
           return new Promise<void>((resolve) => setTimeout(resolve, 30));
         },
         onDone: (data) => {
+          streamFinished = true;
           setIsStreaming(false);
           setStreamingContent('');
           setNewChats((prev) => [
@@ -91,6 +93,7 @@ const Container = () => {
           ]);
         },
         onError: (data) => {
+          streamFinished = true;
           setIsStreaming(false);
           setStreamingContent('');
           const errorMessage = ERROR_MESSAGES[data.code] ?? '오류가 발생했어요. 다시 시도해주세요.';
@@ -105,8 +108,20 @@ const Container = () => {
         },
       });
     } catch {
+      streamFinished = true;
       setIsStreaming(false);
       setStreamingContent('');
+    } finally {
+      if (!streamFinished) {
+        setIsStreaming(false);
+        setStreamingContent('');
+        if (accumulated) {
+          setNewChats((prev) => [
+            ...prev,
+            { id: crypto.randomUUID(), user: CHAT_USER.AI, message: accumulated },
+          ]);
+        }
+      }
     }
   };
 

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -79,6 +79,10 @@ const Container = () => {
           setStreamingContent(accumulated);
           return new Promise<void>((resolve) => setTimeout(resolve, 30));
         },
+        onRetry: () => {
+          accumulated = '';
+          setStreamingContent('');
+        },
         onDone: (data) => {
           streamFinished = true;
           setIsStreaming(false);

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -5,9 +5,16 @@ import { useEffect, useRef, useState } from 'react';
 import { Header, HEADER_VARIANT, TextfieldChat } from '@/components';
 import { CHAT_BG_VARIANT, CHAT_USER, type ChatMessage } from '@/constants';
 import { useModal } from '@/hooks';
-import { chatData, useCheckSummaryEligibility, useGetMessages } from '@/lib';
+import { useCheckSummaryEligibility, useGetMessages, useSendMessage } from '@/lib';
 import { Chat } from './Chat';
 import { Modal } from './Modal';
+
+const ERROR_MESSAGES: Record<string, string> = {
+  AI_QUOTA_EXHAUSTED: '오늘 대화 한도를 초과했어요. 내일 다시 시도해주세요.',
+  AI_PROVIDER_ERROR: '일시적인 오류가 발생했어요. 잠시 후 다시 시도해주세요.',
+  AI_PROVIDER_TRANSIENT: '일시적인 오류가 발생했어요. 잠시 후 다시 시도해주세요.',
+  AI_STREAM_INTERRUPTED: '응답 중 연결이 끊겼어요. 다시 시도해주세요.',
+};
 
 const Container = () => {
   const router = useRouter();
@@ -32,31 +39,50 @@ const Container = () => {
       message: msg.content,
     }));
 
+  const { send, isStreaming, streamingContent } = useSendMessage(sessionId);
+
   const allChats = [...historyChats, ...newChats];
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [allChats.length]);
+  }, [allChats.length, streamingContent]);
 
-  const handleSend = () => {
+  const handleSend = async () => {
     const trimmedMessage = message.trim();
-    if (!trimmedMessage) return;
+    if (!trimmedMessage || isStreaming) return;
 
-    const newUserMessage: ChatMessage = {
+    setMessage('');
+
+    const userMessage: ChatMessage = {
       id: crypto.randomUUID(),
       user: CHAT_USER.ME,
       message: trimmedMessage,
     };
+    setNewChats((prev) => [...prev, userMessage]);
 
-    const newAiMessage = chatData.map((msg) => ({
-      id: crypto.randomUUID(),
-      user: CHAT_USER.AI,
-      message: msg,
-    }));
-
-    setNewChats((prev) => [...prev, newUserMessage, ...newAiMessage]);
-
-    setMessage('');
+    await send(trimmedMessage, {
+      onDone: (data, accumulated) => {
+        setNewChats((prev) => [
+          ...prev,
+          {
+            id: String(data.messageId),
+            user: CHAT_USER.AI,
+            message: accumulated,
+          },
+        ]);
+      },
+      onError: (data) => {
+        const errorMessage = ERROR_MESSAGES[data.code] ?? '오류가 발생했어요. 다시 시도해주세요.';
+        setNewChats((prev) => [
+          ...prev,
+          {
+            id: crypto.randomUUID(),
+            user: CHAT_USER.AI,
+            message: errorMessage,
+          },
+        ]);
+      },
+    });
   };
 
   return (
@@ -76,6 +102,9 @@ const Container = () => {
             {allChats.map((chat) => (
               <Chat key={chat.id} user={chat.user} message={chat.message} />
             ))}
+            {isStreaming && streamingContent && (
+              <Chat user={CHAT_USER.AI} message={streamingContent} />
+            )}
             <div ref={bottomRef} />
           </div>
         </main>

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Header, HEADER_VARIANT, TextfieldChat } from '@/components';
 import { CHAT_BG_VARIANT, CHAT_USER, type ChatMessage } from '@/constants';
 import { useModal } from '@/hooks';
-import { chatData, useCheckSummaryEligibility } from '@/lib';
+import { chatData, useCheckSummaryEligibility, useGetMessages } from '@/lib';
 import { Chat } from './Chat';
 import { Modal } from './Modal';
 
@@ -18,20 +18,31 @@ const Container = () => {
 
   const bottomRef = useRef<HTMLDivElement>(null);
   const [message, setMessage] = useState('');
-  const [chats, setChats] = useState<ChatMessage[]>([]);
+  const [newChats, setNewChats] = useState<ChatMessage[]>([]);
 
   const { data: eligibilityData } = useCheckSummaryEligibility(sessionId);
   const canSummarize = eligibilityData?.eligible ?? false;
 
+  const { data: messagesData } = useGetMessages(sessionId);
+  const historyChats: ChatMessage[] = (messagesData?.pages ?? [])
+    .flatMap((page) => page.messages)
+    .map((msg) => ({
+      id: msg.id,
+      user: msg.role === 'user' ? CHAT_USER.ME : CHAT_USER.AI,
+      message: msg.content,
+    }));
+
+  const allChats = [...historyChats, ...newChats];
+
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [chats]);
+  }, [allChats.length]);
 
   const handleSend = () => {
     const trimmedMessage = message.trim();
     if (!trimmedMessage) return;
 
-    const newUserMessage = {
+    const newUserMessage: ChatMessage = {
       id: crypto.randomUUID(),
       user: CHAT_USER.ME,
       message: trimmedMessage,
@@ -43,7 +54,7 @@ const Container = () => {
       message: msg,
     }));
 
-    setChats((prev) => [...prev, newUserMessage, ...newAiMessage]);
+    setNewChats((prev) => [...prev, newUserMessage, ...newAiMessage]);
 
     setMessage('');
   };
@@ -62,7 +73,7 @@ const Container = () => {
 
         <main className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-[2.4rem] pb-48">
           <div className="flex flex-col gap-[2.8rem]">
-            {chats.map((chat) => (
+            {allChats.map((chat) => (
               <Chat key={chat.id} user={chat.user} message={chat.message} />
             ))}
             <div ref={bottomRef} />

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -33,9 +33,10 @@ const Container = () => {
   const { data: messagesData } = useGetMessages(sessionId);
   const historyChats: ChatMessage[] = (messagesData?.pages ?? [])
     .flatMap((page) => page.messages)
+    .reverse()
     .map((msg) => ({
       id: msg.id,
-      user: msg.role === 'user' ? CHAT_USER.ME : CHAT_USER.AI,
+      user: msg.role === 'USER' ? CHAT_USER.ME : CHAT_USER.AI,
       message: msg.content,
     }));
 

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -72,6 +72,7 @@ const Container = () => {
         onToken: (delta) => {
           accumulated += delta;
           setStreamingContent(accumulated);
+          return new Promise<void>((resolve) => setTimeout(resolve, 30));
         },
         onDone: (data) => {
           setIsStreaming(false);

--- a/src/constants/pathName.ts
+++ b/src/constants/pathName.ts
@@ -1,6 +1,10 @@
 export const PATH_NAME = {
   main: () => '/',
 
+  chat: {
+    detail: (sessionId: string) => `/chat/${sessionId}`,
+  },
+
   register: {
     list: () => '/register',
     complete: () => '/register/complete',

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -23,6 +23,7 @@ export const QUERY_KEY = {
    * AI 채팅
    */
   aiChat: {
+    messages: (sessionId: string) => ['aiChat', 'messages', sessionId],
     summaryEligibility: (sessionId: string) => ['aiChat', 'summaryEligibility', sessionId],
   },
 } as const;

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -18,4 +18,11 @@ export const QUERY_KEY = {
     list: ['delivery', 'list'],
     updateDefault: ['delivery', 'updateDefault'],
   },
+
+  /*
+   * AI 채팅
+   */
+  aiChat: {
+    summaryEligibility: (sessionId: string) => ['aiChat', 'summaryEligibility', sessionId],
+  },
 } as const;

--- a/src/lib/api/http/clientAuthHttp.ts
+++ b/src/lib/api/http/clientAuthHttp.ts
@@ -58,4 +58,17 @@ export const clientAuthHttp = {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
   },
+
+  stream: (url: string, body?: unknown): Promise<Response> => {
+    const token = getClientToken();
+    return fetch(`${API_URL}${url}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      credentials: 'include',
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  },
 };

--- a/src/lib/api/http/index.ts
+++ b/src/lib/api/http/index.ts
@@ -1,1 +1,3 @@
+export { clientAuthHttp } from './clientAuthHttp';
+export { HttpError } from './httpBase';
 export { publicHttp } from './publicHttp';

--- a/src/lib/api/services/chat/chat.client.ts
+++ b/src/lib/api/services/chat/chat.client.ts
@@ -66,27 +66,43 @@ export const streamChatMessage = async (
     buffer = parts.pop() ?? '';
 
     for (const part of parts) {
-      const eventMatch = part.match(/^event: (\w+)/m);
-      const dataMatch = part.match(/^data: (.+)/m);
-      if (!eventMatch || !dataMatch) continue;
+      const lines = part.split('\n');
+      let eventType = '';
+      const dataLines: string[] = [];
 
-      const eventType = eventMatch[1];
+      for (const line of lines) {
+        if (line.startsWith('event:')) {
+          eventType = line.slice(6).trim();
+        } else if (line.startsWith('data:')) {
+          dataLines.push(line.slice(5).trim());
+        }
+      }
+
+      if (!eventType || dataLines.length === 0) continue;
+
       let data: unknown;
       try {
-        data = JSON.parse(dataMatch[1]);
+        data = JSON.parse(dataLines.join('\n'));
       } catch {
+        console.warn('[SSE] JSON parse failed for event:', eventType, dataLines.join('\n'));
         continue;
       }
+
+      console.warn('[SSE] event:', eventType, data);
 
       if (eventType === 'token') {
         const parsed = TokenEventSchema.safeParse(data);
         if (parsed.success) {
           callbacks.onToken(parsed.data.delta);
+        } else {
+          console.warn('[SSE] token schema failed:', parsed.error.issues, data);
         }
       } else if (eventType === 'done') {
         const parsed = DoneEventSchema.safeParse(data);
         if (parsed.success) {
           callbacks.onDone(parsed.data);
+        } else {
+          console.warn('[SSE] done schema failed:', parsed.error.issues, data);
         }
       } else if (eventType === 'error') {
         const parsed = ErrorEventSchema.safeParse(data);
@@ -98,6 +114,8 @@ export const streamChatMessage = async (
             return streamChatMessage(sessionId, content, callbacks, retryCount + 1);
           }
           callbacks.onError(parsed.data);
+        } else {
+          console.warn('[SSE] error schema failed:', parsed.error.issues, data);
         }
       }
     }

--- a/src/lib/api/services/chat/chat.client.ts
+++ b/src/lib/api/services/chat/chat.client.ts
@@ -16,7 +16,7 @@ export const createChatSession = async (): Promise<number> => {
 };
 
 export type StreamCallbacks = {
-  onToken: (delta: string) => void;
+  onToken: (delta: string) => void | Promise<void>;
   onDone: (data: DoneEvent) => void;
   onError: (data: ErrorEvent) => void;
 };
@@ -93,7 +93,7 @@ export const streamChatMessage = async (
       if (eventType === 'token') {
         const parsed = TokenEventSchema.safeParse(data);
         if (parsed.success) {
-          callbacks.onToken(parsed.data.delta);
+          await callbacks.onToken(parsed.data.delta);
         } else {
           console.warn('[SSE] token schema failed:', parsed.error.issues, data);
         }

--- a/src/lib/api/services/chat/chat.client.ts
+++ b/src/lib/api/services/chat/chat.client.ts
@@ -19,6 +19,7 @@ export type StreamCallbacks = {
   onToken: (delta: string) => void | Promise<void>;
   onDone: (data: DoneEvent) => void;
   onError: (data: ErrorEvent) => void;
+  onRetry?: () => void;
 };
 
 export const streamChatMessage = async (
@@ -41,6 +42,7 @@ export const streamChatMessage = async (
   // pre-stream rate limit → Retry-After 헤더 확인 후 재시도
   if (response.status === 429 && retryCount < SSE_RETRY_MAX) {
     const retryAfter = Number(response.headers.get('Retry-After') ?? 5);
+    callbacks.onRetry?.();
     await sleep(retryAfter * 1000);
     return streamChatMessage(sessionId, content, callbacks, retryCount + 1);
   }
@@ -110,6 +112,7 @@ export const streamChatMessage = async (
           if (parsed.data.code === 'AI_RATE_LIMIT_BURST' && retryCount < SSE_RETRY_MAX) {
             const retryAfter = parsed.data.rateLimit?.retryAfterSeconds ?? 5;
             reader.cancel();
+            callbacks.onRetry?.();
             await sleep(retryAfter * 1000);
             return streamChatMessage(sessionId, content, callbacks, retryCount + 1);
           }

--- a/src/lib/api/services/chat/chat.client.ts
+++ b/src/lib/api/services/chat/chat.client.ts
@@ -1,0 +1,105 @@
+import { ENDPOINTS } from '@/constants';
+import { clientAuthHttp, HttpError } from '@/lib';
+import { type CreateSessionResponse, type DoneEvent, type ErrorEvent } from './chat.type';
+import { DoneEventSchema, ErrorEventSchema, TokenEventSchema } from './chat.zod';
+
+const SSE_RETRY_MAX = 3;
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export const createChatSession = async (): Promise<number> => {
+  const response = await clientAuthHttp.post<void, CreateSessionResponse>(
+    ENDPOINTS.AI_CHAT.createSession(),
+  );
+
+  return response.data.sessionId;
+};
+
+export type StreamCallbacks = {
+  onToken: (delta: string) => void;
+  onDone: (data: DoneEvent) => void;
+  onError: (data: ErrorEvent) => void;
+};
+
+export const streamChatMessage = async (
+  sessionId: string,
+  content: string,
+  callbacks: StreamCallbacks,
+  retryCount = 0,
+): Promise<void> => {
+  let response: Response;
+
+  try {
+    response = await clientAuthHttp.stream(ENDPOINTS.AI_CHAT.sendMessage(sessionId), { content });
+  } catch (error) {
+    throw new HttpError({
+      message: error instanceof Error ? error.message : 'Network Error',
+      status: 503,
+    });
+  }
+
+  // pre-stream rate limit → Retry-After 헤더 확인 후 재시도
+  if (response.status === 429 && retryCount < SSE_RETRY_MAX) {
+    const retryAfter = Number(response.headers.get('Retry-After') ?? 5);
+    await sleep(retryAfter * 1000);
+    return streamChatMessage(sessionId, content, callbacks, retryCount + 1);
+  }
+
+  if (!response.ok) {
+    throw new HttpError({ message: 'API Error', status: response.status });
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) throw new HttpError({ message: 'No response body', status: 502 });
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+
+    // SSE 메시지는 \n\n 단위로 구분
+    const parts = buffer.split('\n\n');
+    buffer = parts.pop() ?? '';
+
+    for (const part of parts) {
+      const eventMatch = part.match(/^event: (\w+)/m);
+      const dataMatch = part.match(/^data: (.+)/m);
+      if (!eventMatch || !dataMatch) continue;
+
+      const eventType = eventMatch[1];
+      let data: unknown;
+      try {
+        data = JSON.parse(dataMatch[1]);
+      } catch {
+        continue;
+      }
+
+      if (eventType === 'token') {
+        const parsed = TokenEventSchema.safeParse(data);
+        if (parsed.success) {
+          callbacks.onToken(parsed.data.delta);
+        }
+      } else if (eventType === 'done') {
+        const parsed = DoneEventSchema.safeParse(data);
+        if (parsed.success) {
+          callbacks.onDone(parsed.data);
+        }
+      } else if (eventType === 'error') {
+        const parsed = ErrorEventSchema.safeParse(data);
+        if (parsed.success) {
+          if (parsed.data.code === 'AI_RATE_LIMIT_BURST' && retryCount < SSE_RETRY_MAX) {
+            const retryAfter = parsed.data.rateLimit?.retryAfterSeconds ?? 5;
+            reader.cancel();
+            await sleep(retryAfter * 1000);
+            return streamChatMessage(sessionId, content, callbacks, retryCount + 1);
+          }
+          callbacks.onError(parsed.data);
+        }
+      }
+    }
+  }
+};

--- a/src/lib/api/services/chat/chat.client.ts
+++ b/src/lib/api/services/chat/chat.client.ts
@@ -90,8 +90,6 @@ export const streamChatMessage = async (
         continue;
       }
 
-      console.warn('[SSE] event:', eventType, data);
-
       if (eventType === 'token') {
         const parsed = TokenEventSchema.safeParse(data);
         if (parsed.success) {
@@ -111,7 +109,7 @@ export const streamChatMessage = async (
         if (parsed.success) {
           if (parsed.data.code === 'AI_RATE_LIMIT_BURST' && retryCount < SSE_RETRY_MAX) {
             const retryAfter = parsed.data.rateLimit?.retryAfterSeconds ?? 5;
-            reader.cancel();
+            await reader.cancel();
             callbacks.onRetry?.();
             await sleep(retryAfter * 1000);
             return streamChatMessage(sessionId, content, callbacks, retryCount + 1);

--- a/src/lib/api/services/chat/chat.service.ts
+++ b/src/lib/api/services/chat/chat.service.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+import { createChatSession, streamChatMessage } from './chat.client';
+import { type DoneEvent, type ErrorEvent } from './chat.type';
+
+export const useCreateChatSession = () => {
+  return useMutation({
+    mutationFn: createChatSession,
+  });
+};
+
+type UseSendMessageCallbacks = {
+  onToken?: (delta: string, accumulated: string) => void;
+  onDone?: (data: DoneEvent, accumulated: string) => void;
+  onError?: (data: ErrorEvent) => void;
+};
+
+export const useSendMessage = (sessionId: string) => {
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [streamingContent, setStreamingContent] = useState('');
+
+  const send = async (content: string, callbacks: UseSendMessageCallbacks = {}) => {
+    setIsStreaming(true);
+    setStreamingContent('');
+
+    let accumulated = '';
+
+    try {
+      await streamChatMessage(sessionId, content, {
+        onToken: (delta) => {
+          accumulated += delta;
+          setStreamingContent(accumulated);
+          callbacks.onToken?.(delta, accumulated);
+        },
+        onDone: (data) => {
+          setIsStreaming(false);
+          setStreamingContent('');
+          callbacks.onDone?.(data, accumulated);
+        },
+        onError: (data) => {
+          setIsStreaming(false);
+          setStreamingContent('');
+          callbacks.onError?.(data);
+        },
+      });
+    } catch {
+      setIsStreaming(false);
+      setStreamingContent('');
+    }
+  };
+
+  return { send, isStreaming, streamingContent };
+};

--- a/src/lib/api/services/chat/chat.service.ts
+++ b/src/lib/api/services/chat/chat.service.ts
@@ -1,55 +1,10 @@
 'use client';
 
 import { useMutation } from '@tanstack/react-query';
-import { useState } from 'react';
-import { createChatSession, streamChatMessage } from './chat.client';
-import { type DoneEvent, type ErrorEvent } from './chat.type';
+import { createChatSession } from './chat.client';
 
 export const useCreateChatSession = () => {
   return useMutation({
     mutationFn: createChatSession,
   });
-};
-
-type UseSendMessageCallbacks = {
-  onToken?: (delta: string, accumulated: string) => void;
-  onDone?: (data: DoneEvent, accumulated: string) => void;
-  onError?: (data: ErrorEvent) => void;
-};
-
-export const useSendMessage = (sessionId: string) => {
-  const [isStreaming, setIsStreaming] = useState(false);
-  const [streamingContent, setStreamingContent] = useState('');
-
-  const send = async (content: string, callbacks: UseSendMessageCallbacks = {}) => {
-    setIsStreaming(true);
-    setStreamingContent('');
-
-    let accumulated = '';
-
-    try {
-      await streamChatMessage(sessionId, content, {
-        onToken: (delta) => {
-          accumulated += delta;
-          setStreamingContent(accumulated);
-          callbacks.onToken?.(delta, accumulated);
-        },
-        onDone: (data) => {
-          setIsStreaming(false);
-          setStreamingContent('');
-          callbacks.onDone?.(data, accumulated);
-        },
-        onError: (data) => {
-          setIsStreaming(false);
-          setStreamingContent('');
-          callbacks.onError?.(data);
-        },
-      });
-    } catch {
-      setIsStreaming(false);
-      setStreamingContent('');
-    }
-  };
-
-  return { send, isStreaming, streamingContent };
 };

--- a/src/lib/api/services/chat/chat.type.ts
+++ b/src/lib/api/services/chat/chat.type.ts
@@ -1,0 +1,18 @@
+import { type z } from 'zod';
+import {
+  CreateSessionDataSchema,
+  CreateSessionResponseSchema,
+  DoneEventSchema,
+  ErrorEventSchema,
+  RateLimitSchema,
+  SendMessageRequestSchema,
+  TokenEventSchema,
+} from './chat.zod';
+
+export type CreateSessionData = z.infer<typeof CreateSessionDataSchema>;
+export type CreateSessionResponse = z.infer<typeof CreateSessionResponseSchema>;
+export type SendMessageRequest = z.infer<typeof SendMessageRequestSchema>;
+export type TokenEvent = z.infer<typeof TokenEventSchema>;
+export type DoneEvent = z.infer<typeof DoneEventSchema>;
+export type RateLimit = z.infer<typeof RateLimitSchema>;
+export type ErrorEvent = z.infer<typeof ErrorEventSchema>;

--- a/src/lib/api/services/chat/chat.zod.ts
+++ b/src/lib/api/services/chat/chat.zod.ts
@@ -1,0 +1,38 @@
+import z from 'zod';
+import { createResponseSchema } from '@/lib';
+
+export const CreateSessionDataSchema = z.object({
+  sessionId: z.number(),
+});
+
+export const CreateSessionResponseSchema = createResponseSchema(CreateSessionDataSchema);
+
+export const SendMessageRequestSchema = z.object({
+  content: z.string().min(1),
+});
+
+export const TokenEventSchema = z.object({
+  delta: z.string(),
+});
+
+export const DoneEventSchema = z.object({
+  messageId: z.number(),
+  tokenCount: z.number(),
+  createdAt: z.string(),
+});
+
+export const RateLimitSchema = z.object({
+  retryAfterSeconds: z.number(),
+});
+
+export const ErrorEventSchema = z.object({
+  code: z.enum([
+    'AI_RATE_LIMIT_BURST',
+    'AI_QUOTA_EXHAUSTED',
+    'AI_PROVIDER_ERROR',
+    'AI_PROVIDER_TRANSIENT',
+    'AI_STREAM_INTERRUPTED',
+  ]),
+  message: z.string(),
+  rateLimit: RateLimitSchema.optional(),
+});

--- a/src/lib/api/services/chat/chat.zod.ts
+++ b/src/lib/api/services/chat/chat.zod.ts
@@ -16,8 +16,8 @@ export const TokenEventSchema = z.object({
 });
 
 export const DoneEventSchema = z.object({
-  messageId: z.number(),
-  tokenCount: z.number(),
+  messageId: z.coerce.number(),
+  tokenCount: z.coerce.number(),
   createdAt: z.string(),
 });
 

--- a/src/lib/api/services/chat/index.ts
+++ b/src/lib/api/services/chat/index.ts
@@ -1,0 +1,4 @@
+export * from './chat.client';
+export * from './chat.service';
+export * from './chat.type';
+export * from './chat.zod';

--- a/src/lib/api/services/index.ts
+++ b/src/lib/api/services/index.ts
@@ -1,4 +1,5 @@
 export * from './books';
+export * from './chat';
 export * from './messages';
 export * from './summary-eligibility';
 export * from './user-books';

--- a/src/lib/api/services/index.ts
+++ b/src/lib/api/services/index.ts
@@ -1,3 +1,4 @@
 export * from './books';
+export * from './summary-eligibility';
 export * from './user-books';
 export * from './users';

--- a/src/lib/api/services/index.ts
+++ b/src/lib/api/services/index.ts
@@ -1,4 +1,5 @@
 export * from './books';
+export * from './messages';
 export * from './summary-eligibility';
 export * from './user-books';
 export * from './users';

--- a/src/lib/api/services/messages/index.ts
+++ b/src/lib/api/services/messages/index.ts
@@ -1,0 +1,4 @@
+export * from './message.type';
+export * from './message.zod';
+export * from './messages.client';
+export * from './messages.service';

--- a/src/lib/api/services/messages/message.type.ts
+++ b/src/lib/api/services/messages/message.type.ts
@@ -1,0 +1,12 @@
+import { type z } from 'zod';
+import {
+  MessageItemSchema,
+  MessagesDataSchema,
+  MessagesRequestSchema,
+  MessagesResponseSchema,
+} from './message.zod';
+
+export type MessageItem = z.infer<typeof MessageItemSchema>;
+export type MessagesData = z.infer<typeof MessagesDataSchema>;
+export type MessagesResponse = z.infer<typeof MessagesResponseSchema>;
+export type MessagesRequest = z.infer<typeof MessagesRequestSchema>;

--- a/src/lib/api/services/messages/message.type.ts
+++ b/src/lib/api/services/messages/message.type.ts
@@ -1,4 +1,4 @@
-import { type z } from 'zod';
+import z from 'zod';
 import {
   MessageItemSchema,
   MessagesDataSchema,

--- a/src/lib/api/services/messages/message.zod.ts
+++ b/src/lib/api/services/messages/message.zod.ts
@@ -1,0 +1,24 @@
+import z from 'zod';
+import { createResponseSchema } from '@/lib';
+
+export const MessageItemSchema = z.object({
+  id: z.string(),
+  role: z.enum(['user', 'assistant']),
+  content: z.string(),
+  createdAt: z.string(),
+});
+
+export const MessagesDataSchema = z.object({
+  messages: z.array(MessageItemSchema),
+  page: z.number(),
+  size: z.number(),
+  hasNext: z.boolean(),
+});
+
+export const MessagesResponseSchema = createResponseSchema(MessagesDataSchema);
+
+export const MessagesRequestSchema = z.object({
+  sessionId: z.string(),
+  page: z.number().int().min(1),
+  size: z.number().int().min(1),
+});

--- a/src/lib/api/services/messages/message.zod.ts
+++ b/src/lib/api/services/messages/message.zod.ts
@@ -3,7 +3,7 @@ import { createResponseSchema } from '@/lib';
 
 export const MessageItemSchema = z.object({
   id: z.string(),
-  role: z.enum(['user', 'assistant']),
+  role: z.enum(['USER', 'ASSISTANT']),
   content: z.string(),
   createdAt: z.string(),
 });

--- a/src/lib/api/services/messages/messages.client.ts
+++ b/src/lib/api/services/messages/messages.client.ts
@@ -1,0 +1,16 @@
+import { ENDPOINTS } from '@/constants';
+import { clientAuthHttp } from '@/lib/api/http/clientAuthHttp';
+import { type MessagesRequest, type MessagesResponse } from './message.type';
+
+export const getMessages = async (params: MessagesRequest) => {
+  const query = new URLSearchParams({
+    page: String(params.page),
+    size: String(params.size),
+  });
+
+  const response = await clientAuthHttp.get<MessagesResponse>(
+    `${ENDPOINTS.AI_CHAT.getMessages(params.sessionId)}?${query.toString()}`,
+  );
+
+  return response.data;
+};

--- a/src/lib/api/services/messages/messages.service.ts
+++ b/src/lib/api/services/messages/messages.service.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '@/constants';
+import { getMessages } from './messages.client';
+
+const MESSAGES_PAGE_SIZE = 20;
+
+export const useGetMessages = (sessionId: string) => {
+  return useInfiniteQuery({
+    queryKey: QUERY_KEY.aiChat.messages(sessionId),
+    queryFn: ({ pageParam }) =>
+      getMessages({ sessionId, page: pageParam as number, size: MESSAGES_PAGE_SIZE }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
+    enabled: !!sessionId,
+  });
+};

--- a/src/lib/api/services/summary-eligibility/index.ts
+++ b/src/lib/api/services/summary-eligibility/index.ts
@@ -1,0 +1,4 @@
+export * from './summary-eligibility.client';
+export * from './summary-eligibility.service';
+export * from './summary-eligibility.type';
+export * from './summary-eligibility.zod';

--- a/src/lib/api/services/summary-eligibility/summary-eligibility.client.ts
+++ b/src/lib/api/services/summary-eligibility/summary-eligibility.client.ts
@@ -1,0 +1,11 @@
+import { ENDPOINTS } from '@/constants';
+import { clientAuthHttp } from '@/lib/api/http/clientAuthHttp';
+import { type SummaryEligibilityResponse } from './summary-eligibility.type';
+
+export const checkSummaryEligibility = async (sessionId: string) => {
+  const response = await clientAuthHttp.get<SummaryEligibilityResponse>(
+    ENDPOINTS.AI_CHAT.checkSummaryEligibility(sessionId),
+  );
+
+  return response.data;
+};

--- a/src/lib/api/services/summary-eligibility/summary-eligibility.service.ts
+++ b/src/lib/api/services/summary-eligibility/summary-eligibility.service.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '@/constants';
+import { checkSummaryEligibility } from './summary-eligibility.client';
+
+export const useCheckSummaryEligibility = (sessionId: string) => {
+  return useQuery({
+    queryKey: QUERY_KEY.aiChat.summaryEligibility(sessionId),
+    queryFn: () => checkSummaryEligibility(sessionId),
+    enabled: !!sessionId,
+  });
+};

--- a/src/lib/api/services/summary-eligibility/summary-eligibility.type.ts
+++ b/src/lib/api/services/summary-eligibility/summary-eligibility.type.ts
@@ -1,0 +1,8 @@
+import { type z } from 'zod';
+import {
+  SummaryEligibilityDataSchema,
+  SummaryEligibilityResponseSchema,
+} from './summary-eligibility.zod';
+
+export type SummaryEligibilityData = z.infer<typeof SummaryEligibilityDataSchema>;
+export type SummaryEligibilityResponse = z.infer<typeof SummaryEligibilityResponseSchema>;

--- a/src/lib/api/services/summary-eligibility/summary-eligibility.zod.ts
+++ b/src/lib/api/services/summary-eligibility/summary-eligibility.zod.ts
@@ -1,0 +1,8 @@
+import z from 'zod';
+import { createResponseSchema } from '@/lib';
+
+export const SummaryEligibilityDataSchema = z.object({
+  eligible: z.boolean(),
+});
+
+export const SummaryEligibilityResponseSchema = createResponseSchema(SummaryEligibilityDataSchema);


### PR DESCRIPTION
## 📌 PR 제목

[FEAT] 채팅 API 연결 및 SSE 스트리밍 구현

---

## 🔗 관련 이슈 (Issue)

- Closes #69

---

## ✅ 작업 내용

채팅 페이지에 필요한 API 4종을 연결하고, SSE 스트리밍으로 AI 답변이 실시간으로 한 글자씩 표시되도록 구현했습니다.

**API 연결**
- `GET /ai-chat/sessions/{sessionId}/summary-draft/eligibility` → Header `summarizeActive` 제어
- `GET /ai-chat/sessions/{sessionId}/messages` → 채팅 히스토리 표시 (oldest-first 정렬, role 기반 ME/AI 구분)
- `POST /ai-chat/sessions` → 세션 생성
- `POST /ai-chat/sessions/{sessionId}/messages` → SSE 스트리밍으로 AI 답변 실시간 표시

**스트리밍 구현**
- `clientAuthHttp.stream()` 메서드 추가 — `fetch` + `ReadableStream`으로 raw SSE 수신
- line-by-line SSE 파싱으로 `event:token` / `event: token` 포맷 모두 대응
- 토큰마다 `setTimeout(30ms)` await로 글자가 순차적으로 타이핑되는 효과 구현
- 429 / `AI_RATE_LIMIT_BURST` 자동 재시도 (최대 3회)
- `isStreaming` 상태를 Container 로컬로 관리해 렌더링 반영 보장
- `streamFinished` 플래그 + `finally` 블록으로 스트리밍이 어떻게 끝나도 `isStreaming` 항상 초기화
- 마지막 AI 메시지와 스트리밍 버블에만 아이콘 표시

---

## 🖥️ 테스트 방법

1. 채팅 페이지 진입
2. 메시지 입력 후 전송
3. 아래 항목 확인
   - AI 답변이 한 글자씩 타이핑되며 표시되는지 확인
   - 답변 수신 완료 후 다시 메시지 전송 가능한지 확인
   - 히스토리 메시지가 오래된 순서대로 정렬되는지 확인
   - 내 메시지와 AI 메시지 스타일링이 올바르게 구분되는지 확인
   - 마지막 AI 메시지에만 아이콘이 표시되는지 확인
   - 요약 가능 여부에 따라 Header CTA 버튼 활성/비활성 확인

> ## 연결 완료한 API
- 세션의 메시지 이력 조회
- 감상문 초안 생성 가능 여부 조회
- 메시지 전송 (SSE 스트리밍 응답)

> ## 추후 디테일
- AI 채팅 너비 조정
- AI 채팅 답변 로딩 중일 때 애니메이션 조정
- 채팅 스크롤
- 로딩 중일 때 사진 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅 세션별 메시지 저장 및 관리 기능 추가
  * 실시간 스트리밍을 통한 AI 응답 즉시 표시
  * 이전 채팅 메시지 히스토리 조회 기능 추가
  * 요약 기능 가능 여부 확인 기능 추가

* **개선 사항**
  * 채팅 UI에서 스트리밍 상태 시각화 개선
  * 헤더 동작 및 상호작용 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->