### PR TITLE
[FIX] 빌드 오류 수정 — queryKey 중복 키 및 PATH_NAME 타입 오류

### DIFF
--- a/src/app/actions/userBooks.ts
+++ b/src/app/actions/userBooks.ts
@@ -1,0 +1,7 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+export const revalidateHomeAction = async () => {
+  revalidatePath('/');
+};

--- a/src/components/pages/Main/Footer.tsx
+++ b/src/components/pages/Main/Footer.tsx
@@ -24,7 +24,7 @@ export const MainFooter = (props: Props) => {
 
   const handleSend = () => {
     createSession(selectedId, {
-      onSuccess: () => router.push(PATH_NAME.chat()),
+      onSuccess: (data) => router.push(PATH_NAME.chat.detail(String(data.sessionId))),
     });
   };
 

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -7,13 +7,6 @@ export const QUERY_KEY = {
   },
 
   /*
-   * AI 채팅 세션
-   */
-  aiChat: {
-    sessions: (userBookId: number) => ['aiChat', 'sessions', userBookId] as const,
-  },
-
-  /*
    * EXAMPLE
    * 배달 권역
    */
@@ -37,7 +30,8 @@ export const QUERY_KEY = {
    * AI 채팅
    */
   aiChat: {
-    messages: (sessionId: string) => ['aiChat', 'messages', sessionId],
-    summaryEligibility: (sessionId: string) => ['aiChat', 'summaryEligibility', sessionId],
+    sessions: (userBookId: number) => ['aiChat', 'sessions', userBookId] as const,
+    messages: (sessionId: string) => ['aiChat', 'messages', sessionId] as const,
+    summaryEligibility: (sessionId: string) => ['aiChat', 'summaryEligibility', sessionId] as const,
   },
 } as const;


### PR DESCRIPTION
## 📌 PR 제목

[FIX] 빌드 오류 수정 — queryKey 중복 키 및 PATH_NAME 타입 오류

---

## 🔗 관련 이슈 (Issue)

- Related to #76, #69

---

## ✅ 작업 내용

두 feature 브랜치가 각각 `QUERY_KEY.aiChat`을 추가한 채 dev에 머지되면서 중복 키 타입 오류가 발생했고, `PATH_NAME.chat`을 함수처럼 호출한 타입 오류도 함께 발생하여 Amplify 빌드가 실패했습니다.

- `src/constants/queryKey.ts`: 중복 선언된 `aiChat` 키를 하나로 합치고 `sessions`, `messages`, `summaryEligibility` 모두 포함
- `src/components/pages/Main/Footer.tsx`: `PATH_NAME.chat()` → `PATH_NAME.chat.detail(String(data.sessionId))` 로 수정
- `src/app/actions/userBooks.ts`: 홈 화면 revalidation을 위한 Server Action 추가

---

## 🖥️ 테스트 방법

1. `pnpm run build` 실행 후 타입 오류 없이 빌드 성공 확인
2. 홈 화면 진입 후 책 선택 → 채팅 시작 시 올바른 세션 상세 페이지로 이동 확인
