### PR TITLE
[FIX] user-books 서버/클라이언트 함수명 충돌 해결

### DIFF
--- a/src/components/pages/Main/Container.tsx
+++ b/src/components/pages/Main/Container.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import { GradientSky } from '@/assets';
 import { LinkButton } from '@/components';
 import { PATH_NAME } from '@/constants';
-import { getUserBooks, type Session } from '@/lib';
+import { getUserBooksServer, type Session } from '@/lib';
 import { MainBody } from './Body';
 import { MainFooter } from './Footer';
 import { OnboardingSkipButton } from './OnboardingSkipButton';
@@ -82,7 +82,7 @@ export const MainContainer = async ({ session }: Props) => {
   }
 
   // 4. 온보딩 완료 + 책 등록 완료 — 풀버전 (records 있는 것으로 처리)
-  const userBooksData = await getUserBooks().catch(() => null);
+  const userBooksData = await getUserBooksServer().catch(() => null);
   const books = userBooksData?.books ?? [];
   const userBookId = session.lastSelectedUserBookId || books[0]?.userBookId;
 

--- a/src/lib/api/services/user-books/user-books.server.ts
+++ b/src/lib/api/services/user-books/user-books.server.ts
@@ -3,7 +3,7 @@ import { ENDPOINTS } from '@/constants';
 import { publicHttp } from '@/lib';
 import { type UserBookListResponse } from './user-books.type';
 
-export const getUserBooks = cache(async () => {
+export const getUserBooksServer = cache(async () => {
   const response = await publicHttp.get<UserBookListResponse>(ENDPOINTS.USER_BOOKS.list());
 
   return response.data;


### PR DESCRIPTION
## Summary

- `user-books.client.ts`와 `user-books.server.ts`가 동일한 이름 `getUserBooks`를 export하면서 barrel(`index.ts`)에서 TypeScript 에러 발생
- RSC 전용(React `cache` 래핑) 함수를 `getUserBooksServer`로 rename하여 충돌 제거
- `Container.tsx` import 및 호출부 동일하게 업데이트

## Root Cause

```
Type error: Module './user-books.client' has already exported a member named 'getUserBooks'.
Consider explicitly re-exporting to resolve the ambiguity.
```

`export * from './user-books.client'`와 `export * from './user-books.server'` 두 모듈에서 같은 이름이 노출되어 Amplify 빌드 실패.

## Test plan

- [ ] `pnpm run build` 로컬 통과 확인
- [ ] 메인 페이지 정상 렌더링 확인

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 사용자 도서 데이터 로딩 메커니즘 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->