### PR TITLE
[FIX] 홈에서 채팅 진입 시 첫 메시지 누락 및 요약 버튼 미활성화 버그 수정

### DIFF
--- a/src/app/chat/[sessionId]/page.tsx
+++ b/src/app/chat/[sessionId]/page.tsx
@@ -1,5 +1,4 @@
 import { type Metadata } from 'next';
-import { Suspense } from 'react';
 import { ChatContainer } from '@/components';
 
 export const generateMetadata = async (): Promise<Metadata> => ({
@@ -8,11 +7,7 @@ export const generateMetadata = async (): Promise<Metadata> => ({
 });
 
 const ChatPage = () => {
-  return (
-    <Suspense>
-      <ChatContainer />
-    </Suspense>
-  );
+  return <ChatContainer />;
 };
 
 export default ChatPage;

--- a/src/app/chat/[sessionId]/page.tsx
+++ b/src/app/chat/[sessionId]/page.tsx
@@ -1,4 +1,5 @@
 import { type Metadata } from 'next';
+import { Suspense } from 'react';
 import { ChatContainer } from '@/components';
 
 export const generateMetadata = async (): Promise<Metadata> => ({
@@ -7,7 +8,11 @@ export const generateMetadata = async (): Promise<Metadata> => ({
 });
 
 const ChatPage = () => {
-  return <ChatContainer />;
+  return (
+    <Suspense>
+      <ChatContainer />
+    </Suspense>
+  );
 };
 
 export default ChatPage;

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { Header, HEADER_VARIANT, TextfieldChat } from '@/components';
 import { CHAT_BG_VARIANT, CHAT_USER, type ChatMessage, PATH_NAME } from '@/constants';
@@ -27,6 +27,7 @@ const Container = () => {
   const router = useRouter();
   const params = useParams<{ sessionId: string }>();
   const sessionId = params.sessionId;
+  const searchParams = useSearchParams();
 
   const { isOpen, open, close } = useModal();
   const openToast = useToastStore((s) => s.openToast);
@@ -104,11 +105,11 @@ const Container = () => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [allChats.length, streamingContent]);
 
-  const handleSend = async () => {
-    const trimmedMessage = message.trim();
+  const handleSend = async (overrideText?: string) => {
+    const trimmedMessage = (overrideText != null ? overrideText : message).trim();
     if (!trimmedMessage || isStreaming) return;
 
-    setMessage('');
+    if (overrideText == null) setMessage('');
 
     const userMessage: ChatMessage = {
       id: crypto.randomUUID(),
@@ -178,6 +179,17 @@ const Container = () => {
       }
     }
   };
+
+  const initialSentRef = useRef(false);
+  useEffect(() => {
+    if (initialSentRef.current) return;
+    const initial = searchParams.get('m');
+    if (!initial) return;
+    initialSentRef.current = true;
+    router.replace(PATH_NAME.chat.detail(sessionId));
+    void handleSend(initial);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="relative min-h-screen overflow-hidden">

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -57,7 +57,8 @@ const Container = () => {
   const [message, setMessage] = useState('');
   const [newChats, setNewChats] = useState<ChatMessage[]>([]);
 
-  const { data: eligibilityData } = useCheckSummaryEligibility(sessionId);
+  const { data: eligibilityData, refetch: refetchEligibility } =
+    useCheckSummaryEligibility(sessionId);
   const canSummarize = eligibilityData?.eligible ?? false;
 
   const {
@@ -178,6 +179,7 @@ const Container = () => {
           ]);
         }
       }
+      void refetchEligibility();
     }
   };
 

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { Header, HEADER_VARIANT, TextfieldChat } from '@/components';
 import { CHAT_BG_VARIANT, CHAT_USER, type ChatMessage, PATH_NAME } from '@/constants';
@@ -11,6 +11,7 @@ import {
   useCheckSummaryEligibility,
   useCreateSummaryDraft,
   useGetMessages,
+  usePendingChatStore,
   useToastStore,
 } from '@/lib';
 import { Chat } from './Chat';
@@ -27,7 +28,7 @@ const Container = () => {
   const router = useRouter();
   const params = useParams<{ sessionId: string }>();
   const sessionId = params.sessionId;
-  const searchParams = useSearchParams();
+  const consumePendingMessage = usePendingChatStore((s) => s.consume);
 
   const { isOpen, open, close } = useModal();
   const openToast = useToastStore((s) => s.openToast);
@@ -183,10 +184,9 @@ const Container = () => {
   const initialSentRef = useRef(false);
   useEffect(() => {
     if (initialSentRef.current) return;
-    const initial = searchParams.get('m');
+    const initial = consumePendingMessage();
     if (!initial) return;
     initialSentRef.current = true;
-    router.replace(PATH_NAME.chat.detail(sessionId));
     void handleSend(initial);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -179,7 +179,7 @@ const Container = () => {
           ]);
         }
       }
-      void refetchEligibility();
+      if (!canSummarize) void refetchEligibility();
     }
   };
 

--- a/src/components/pages/Main/Footer.tsx
+++ b/src/components/pages/Main/Footer.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { BottomSheet, ChevronIcon, ListItem, TextfieldChat } from '@/components';
 import { PATH_NAME } from '@/constants';
-import { cn, useCreateSession, type UserBookItem } from '@/lib';
+import { cn, useCreateSession, usePendingChatStore, type UserBookItem } from '@/lib';
 
 type Props = {
   books: UserBookItem[];
@@ -23,14 +23,14 @@ export const MainFooter = (props: Props) => {
 
   const selectedBook = books.find((b) => b.userBookId === selectedId);
 
+  const setPendingMessage = usePendingChatStore((s) => s.set);
+
   const handleSend = () => {
     const trimmed = inputValue.trim();
     if (!trimmed) return;
+    setPendingMessage(trimmed);
     createSession(selectedId, {
-      onSuccess: (data) =>
-        router.push(
-          `${PATH_NAME.chat.detail(String(data.sessionId))}?m=${encodeURIComponent(trimmed)}`,
-        ),
+      onSuccess: (data) => router.push(PATH_NAME.chat.detail(String(data.sessionId))),
     });
   };
 

--- a/src/components/pages/Main/Footer.tsx
+++ b/src/components/pages/Main/Footer.tsx
@@ -19,12 +19,18 @@ export const MainFooter = (props: Props) => {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [selectedId, setSelectedId] = useState<number>(books[0]?.userBookId ?? 0);
   const [collapsedCap, setCollapsedCap] = useState<string | undefined>(undefined);
+  const [inputValue, setInputValue] = useState('');
 
   const selectedBook = books.find((b) => b.userBookId === selectedId);
 
   const handleSend = () => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
     createSession(selectedId, {
-      onSuccess: (data) => router.push(PATH_NAME.chat.detail(String(data.sessionId))),
+      onSuccess: (data) =>
+        router.push(
+          `${PATH_NAME.chat.detail(String(data.sessionId))}?m=${encodeURIComponent(trimmed)}`,
+        ),
     });
   };
 
@@ -139,7 +145,11 @@ export const MainFooter = (props: Props) => {
             }}
             role="presentation"
           >
-            <TextfieldChat onSend={handleSend} />
+            <TextfieldChat
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onSend={handleSend}
+            />
           </div>
         </div>
 

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,2 +1,3 @@
 export { useAuthStore } from './useAuthStore';
+export { usePendingChatStore } from './usePendingChatStore';
 export { type ToastItem, useToastStore } from './useToastStore';

--- a/src/lib/stores/usePendingChatStore.ts
+++ b/src/lib/stores/usePendingChatStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+type PendingChatState = {
+  message: string;
+  consume: () => string;
+  set: (message: string) => void;
+};
+
+export const usePendingChatStore = create<PendingChatState>()((setState, getState) => ({
+  message: '',
+  consume: () => {
+    const { message } = getState();
+    setState({ message: '' });
+    return message;
+  },
+  set: (message) => setState({ message }),
+}));


### PR DESCRIPTION
## 🔗 관련 이슈 (Issue)

- Closes #91

---

## ✅ 작업 내용

**버그 1 — 홈에서 입력한 첫 메시지가 채팅 페이지에 표시되지 않음**

`MainFooter`의 `TextfieldChat`이 uncontrolled 상태로 렌더링되어 입력값이 캡처되지 않았고, `handleSend`는 메시지 없이 세션만 생성하고 이동했습니다.

- `inputValue` state 추가, `TextfieldChat`에 `value`/`onChange` 연결
- `usePendingChatStore` (Zustand) 신규 생성 — 페이지 전환 전 메시지를 인메모리로 보관하고 소비 후 즉시 초기화 (`consume()`)
- `ChatContainer` 마운트 시 store에서 메시지를 꺼내 자동 전송

> URL 쿼리 파라미터 대신 Zustand store를 사용해 브라우저 히스토리 및 서버 로그에 대화 내용이 노출되지 않도록 했습니다.

**버그 2 — 대화가 쌓여도 요약 버튼이 활성화되지 않음**

`useCheckSummaryEligibility`가 마운트 시 1회만 호출되고 이후 재조회가 없었습니다.

- AI 응답 스트리밍 종료 후 항상 실행되는 `finally` 블록에 `refetchEligibility()` 추가 (`onDone` / `onError` / 예외 / 비정상 종료 모든 경로 커버)

---

## 🖥️ 테스트 방법

**버그 1**
1. 홈 화면에서 책 선택 후 텍스트 입력
2. 전송 버튼 클릭 → 채팅 페이지 이동
3. 입력했던 메시지가 채팅 화면에 표시되고 AI 응답이 오는지 확인

**버그 2**
1. 채팅 페이지에서 AI와 대화 진행
2. 서버 기준 요약 조건 충족 후 헤더의 요약 버튼이 활성화되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 채팅을 시작할 때 미리 작성한 메시지를 자동으로 전송할 수 있는 초기 메시지 큐 기능이 추가되었습니다. 이를 통해 더 효율적인 채팅 경험을 제공합니다.

## 개선사항
* 채팅 입력창의 상태 관리 메커니즘을 개선하여 사용자 입력이 더욱 안정적으로 처리되고 일관성이 유지됩니다.
* 메시지 스트리밍 완료 후 채팅 요약 이용 자격 상태를 자동으로 새로고침하여 실시간으로 정확한 상태 정보가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->