### PR TITLE
[FEAT] ChatCard 클릭 시 채팅 세션 페이지 이동 연결

### DIFF
--- a/src/components/common/ChatCard/ChatCard.tsx
+++ b/src/components/common/ChatCard/ChatCard.tsx
@@ -97,7 +97,10 @@ export const ChatCard = (props: ChatCardProps) => {
         <button
           type="button"
           aria-label="새로고침"
-          onClick={onRefresh}
+          onClick={(e) => {
+            e.preventDefault();
+            onRefresh?.();
+          }}
           className="relative shrink-0"
         >
           <ReloadIcon className={cn('size-[2.4rem]', chatCardIconColor[color])} />

--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { useEffect, useMemo, useRef } from 'react';
 import { Shelve } from '@/assets';
 import {
@@ -10,6 +11,7 @@ import {
   Header,
   HEADER_VARIANT,
 } from '@/components';
+import { PATH_NAME } from '@/constants';
 import { type SessionStatus, useGetSessions } from '@/lib';
 
 const SESSION_STATUS_TO_CARD: Record<
@@ -71,16 +73,18 @@ export const RecordsBody = (props: Props) => {
           >
             {sessions.map((session, index) => (
               <li key={session.sessionId} className="mb-[-6.4rem]">
-                <ChatCard
-                  color={
-                    CHAT_CARD_COLOR_SEQUENCE[
-                      (sessions.length - 1 - index) % CHAT_CARD_COLOR_SEQUENCE.length
-                    ]
-                  }
-                  status={SESSION_STATUS_TO_CARD[session.status]}
-                  date={formatDate(session.lastChattedDate)}
-                  summary={session.title}
-                />
+                <Link href={PATH_NAME.chat.detail(String(session.sessionId))}>
+                  <ChatCard
+                    color={
+                      CHAT_CARD_COLOR_SEQUENCE[
+                        (sessions.length - 1 - index) % CHAT_CARD_COLOR_SEQUENCE.length
+                      ]
+                    }
+                    status={SESSION_STATUS_TO_CARD[session.status]}
+                    date={formatDate(session.lastChattedDate)}
+                    summary={session.title}
+                  />
+                </Link>
               </li>
             ))}
           </ol>


### PR DESCRIPTION
## 📌 PR 제목

[FEAT] ChatCard 클릭 시 채팅 세션 페이지 이동 연결

---

## 🔗 관련 이슈 (Issue)

- Closes #84

---

## ✅ 작업 내용

메인 화면의 ChatCard를 클릭했을 때 해당 채팅 세션 페이지로 이동하도록 연결했습니다.

- RecordsBody: ChatCard를 next/link의 Link로 감싸 PATH_NAME.chat.detail(sessionId) 경로로 이동하도록 구현
- ChatCard: 에러 상태의 새로고침 버튼 클릭 시 e.preventDefault()를 추가해 Link 네비게이션이 함께 실행되지 않도록 처리

---

## 🖥️ 테스트 방법

1. 메인 페이지 접속
2. ChatCard 목록에서 카드 클릭
3. /chat/sessionId 페이지로 이동 확인
4. 에러 상태 카드의 새로고침 버튼 클릭 시 페이지 이동 없이 새로고침만 동작하는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 채팅 카드를 클릭하여 해당 세션의 상세 페이지로 이동할 수 있습니다.

* **Bug Fixes**
  * 오류 상태의 새로고침 버튼 동작이 개선되어 더욱 안정적으로 작동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->