### PR TITLE
[FIX] ListItem hover 시 커서 및 배경 전환 스타일 추가

### DIFF
--- a/src/components/common/ListItem/listItemVariants.ts
+++ b/src/components/common/ListItem/listItemVariants.ts
@@ -1,7 +1,8 @@
 import { cva } from 'class-variance-authority';
 
 export const listItemVariants = cva(
-  'flex w-full appearance-none items-center gap-[1.6rem] rounded-[2rem] border-0 px-[1.6rem] py-[1.8rem] text-left',
+  'flex w-full cursor-pointer appearance-none items-center gap-[1.6rem] rounded-[2rem] border-0 px-[1.6rem] py-[1.8rem] text-left transition-colors duration-300 hover:bg-gray-alpha-10',
+  // 'flex w-full cursor-pointer appearance-none  items-center gap-[1.6rem] rounded-[2rem] border-0 px-[1.6rem] py-[1.8rem] text-left',
   {
     variants: {
       selected: {

--- a/src/components/common/ListItem/listItemVariants.ts
+++ b/src/components/common/ListItem/listItemVariants.ts
@@ -2,7 +2,6 @@ import { cva } from 'class-variance-authority';
 
 export const listItemVariants = cva(
   'flex w-full cursor-pointer appearance-none items-center gap-[1.6rem] rounded-[2rem] border-0 px-[1.6rem] py-[1.8rem] text-left transition-colors duration-300 hover:bg-gray-alpha-10',
-  // 'flex w-full cursor-pointer appearance-none  items-center gap-[1.6rem] rounded-[2rem] border-0 px-[1.6rem] py-[1.8rem] text-left',
   {
     variants: {
       selected: {


### PR DESCRIPTION
## 📌 PR 제목

[FIX] ListItem hover 시 커서 및 배경 전환 스타일 추가

---

## 🔗 관련 이슈 (Issue)

- Closes #96

---

## ✅ 작업 내용

|As-is|
|---|

https://github.com/user-attachments/assets/50fba744-e825-44c2-a45a-26babd1e7150

|To-be|
|---|

https://github.com/user-attachments/assets/68a10957-ecae-4157-812a-acbcf59ff445

`ListItem` 컴포넌트(`button` 요소)에 마우스 hover 시 UX 개선 스타일을 추가했습니다.

- `cursor-pointer`: `button` 기본 커서(`default`)를 포인터로 변경
- `hover:bg-gray-alpha-10`: hover 시 배경색 표시
- `transition-colors duration-300`: 배경색 전환에 부드러운 트랜지션 적용

변경 파일: `src/components/common/ListItem/listItemVariants.ts`

---

## 🖥️ 테스트 방법

1. `ListItem`이 렌더링되는 화면(책 목록 등) 접속
2. 아이템에 마우스 커서를 올려 포인터로 변경되는지 확인
3. hover 시 배경색이 부드럽게 전환되는지 확인
