### PR TITLE
[FIX] 홈 화면 새로고침 시 Empty UI 깜빡임 현상 수정

### DIFF
--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -45,7 +45,7 @@ export const RecordsBody = (props: Props) => {
   const router = useRouter();
   const { mutateAsync: patchLastSelected } = usePatchLastSelectedUserBook();
   const containerRef = useRef<HTMLOListElement>(null);
-  const { data } = useGetSessions(userBookId);
+  const { data, isPending } = useGetSessions(userBookId);
   const sessions = useMemo(() => data?.sessions ?? [], [data?.sessions]);
 
   useEffect(() => {
@@ -53,7 +53,7 @@ export const RecordsBody = (props: Props) => {
     if (el) el.scrollTop = el.scrollHeight;
   }, [sessions]);
 
-  const isEmpty = sessions.length === 0;
+  const isEmpty = !isPending && sessions.length === 0;
 
   return (
     <main className="relative flex flex-1 flex-col overflow-y-hidden bg-background-primary-base">


### PR DESCRIPTION
## 📌 PR 제목

[FIX] 홈 화면 새로고침 시 Empty UI 깜빡임 현상 수정

---

## 🔗 관련 이슈 (Issue)

- Closes #102

---

## ✅ 작업 내용

홈 화면(RecordsBody)에서 페이지 새로고침 시 세션 데이터가 있음에도 빈 화면이 잠깐 표시되었다가 목록이 나타나는 깜빡임 현상을 수정했습니다.

**원인:** TanStack Query 초기 상태에서 data가 undefined이므로 sessions가 빈 배열로 평가되어 isEmpty = true가 되고, 로딩 중에도 Empty UI가 렌더링되었습니다.

**수정:** useGetSessions에서 isPending을 함께 구독하고, isEmpty = !isPending && sessions.length === 0 조건으로 변경하여 쿼리 완료 후 실제 데이터가 없을 때만 Empty UI를 표시하도록 처리했습니다.

- RecordsBody: isPending 추가 및 isEmpty 조건 수정

|As-is|
|---|

https://github.com/user-attachments/assets/4b808eae-fbe8-43dc-8e7e-28b1c6b04d0c

|To-be|
|---|

https://github.com/user-attachments/assets/f31837a7-8099-4004-8612-0c8b86a86beb

---

## 🖥️ 테스트 방법

1. 세션 데이터가 있는 계정으로 로그인
2. 홈 화면에서 새로고침(F5 또는 hard refresh)
3. Empty UI(책장 이미지)가 깜빡이지 않고 바로 세션 목록이 나타나는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 대화 목록 로딩 중 "대화 없음" 메시지가 표시되는 문제를 수정했습니다. 이제 로딩이 완료될 때까지 해당 메시지를 표시하지 않아 더 나은 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->