### PR TITLE
[QA] 26.05.10 3차 QA

### DIFF
--- a/src/assets/common/svgs/ic-book-cover-placeholder.svg
+++ b/src/assets/common/svgs/ic-book-cover-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="73" viewBox="0 0 50 73" fill="none" preserveAspectRatio="xMidYMid slice">
+  <!-- 알라딘 썸네일 미제공 시 대체 (회색 채우기만 — 외곽선은 목록 카드 레이아웃에서 처리) -->
+  <rect width="50" height="73" fill="#DADDDD" />
+</svg>

--- a/src/assets/common/svgs/index.ts
+++ b/src/assets/common/svgs/index.ts
@@ -1,4 +1,5 @@
 export { default as Arrow } from './ic-arrow.svg?react';
+export { default as BookCoverPlaceholder } from './ic-book-cover-placeholder.svg?react';
 export { default as BookLogo } from './ic-book-logo.svg?react';
 export { default as Bookmark } from './ic-bookmark.svg?react';
 export { default as Check } from './ic-check.svg?react';

--- a/src/components/common/ListItem/ListItem.tsx
+++ b/src/components/common/ListItem/ListItem.tsx
@@ -1,5 +1,9 @@
+'use client';
+
 import { type VariantProps } from 'class-variance-authority';
 import Image from 'next/image';
+import { useState } from 'react';
+import { BookCoverPlaceholder } from '@/assets';
 import { SelectIcon } from '@/components';
 import { cn } from '@/lib';
 import { listItemVariants } from './listItemVariants';
@@ -15,6 +19,44 @@ type Props = VariantProps<typeof listItemVariants> & {
   onClick?: () => void;
 };
 
+/** `trimmedSrc`(key) 변경 시 리마운트로 로드 실패 상태를 초기화한다. */
+type ListItemThumbProps = {
+  trimmedSrc: string;
+  alt: string;
+};
+
+const ListItemThumb = (props: ListItemThumbProps) => {
+  const { trimmedSrc, alt } = props;
+
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const usePlaceholder = trimmedSrc.length === 0 || loadFailed;
+
+  return (
+    <div
+      className={cn(
+        'relative h-[7.3rem] w-20 shrink-0 overflow-hidden rounded-[0.6rem]',
+        !usePlaceholder && 'border border-gray-alpha-100 shadow-[0_0_3.2rem_rgba(0,0,0,0.12)]',
+      )}
+    >
+      {usePlaceholder ? (
+        <BookCoverPlaceholder
+          aria-hidden
+          className="pointer-events-none absolute inset-0 h-full w-full"
+        />
+      ) : (
+        <Image
+          src={trimmedSrc}
+          alt={alt}
+          fill
+          className="pointer-events-none object-cover"
+          onError={() => setLoadFailed(true)}
+        />
+      )}
+    </div>
+  );
+};
+
 export const ListItem = (props: Props) => {
   const {
     imageSrc,
@@ -27,6 +69,8 @@ export const ListItem = (props: Props) => {
     onClick,
   } = props;
 
+  const trimmedSrc = imageSrc.trim();
+
   return (
     <li className="min-w-0 max-w-full">
       <button
@@ -35,9 +79,7 @@ export const ListItem = (props: Props) => {
         onClick={onClick}
         className={cn(listItemVariants({ selected }), 'min-w-0 max-w-full', className)}
       >
-        <div className="relative h-[7.3rem] w-20 shrink-0 overflow-hidden rounded-[0.6rem] border border-gray-alpha-100 shadow-[0_0_3.2rem_rgba(0,0,0,0.12)]">
-          <Image src={imageSrc} alt={imageAlt} fill className="pointer-events-none object-cover" />
-        </div>
+        <ListItemThumb key={trimmedSrc} trimmedSrc={trimmedSrc} alt={imageAlt} />
 
         <div className="flex min-w-0 flex-1 flex-col items-start">
           <p className="title1-bold w-full truncate text-text-default">{title}</p>

--- a/src/components/common/Textfield/TextfieldChat.tsx
+++ b/src/components/common/Textfield/TextfieldChat.tsx
@@ -14,17 +14,23 @@ export const TextfieldChat = (props: Props) => {
   const { status = CHAT_STATUS.DEFAULT, bgVariant = CHAT_BG_VARIANT.GRAY, onSend, ...rest } = props;
 
   const placeholder = CHAT_PLACEHOLDER[status ?? CHAT_STATUS.DEFAULT];
-  const isDisabled = status === CHAT_STATUS.DISABLED || status === CHAT_STATUS.ERROR;
+  const isDisabled =
+    status === CHAT_STATUS.DISABLED ||
+    status === CHAT_STATUS.ERROR ||
+    status === CHAT_STATUS.LOADING;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing && !isDisabled) {
       onSend?.();
     }
     rest.onKeyDown?.(e);
   };
 
   return (
-    <div className={cn(containerVariants({ bgVariant, status }))}>
+    <div
+      className={cn(containerVariants({ bgVariant, status }))}
+      aria-busy={status === CHAT_STATUS.LOADING ? true : undefined}
+    >
       <BaseInput
         disabled={isDisabled}
         className={cn(inputVariants({ status }))}
@@ -34,12 +40,26 @@ export const TextfieldChat = (props: Props) => {
       />
       <button
         type="button"
-        onClick={() => onSend?.()}
+        onClick={() => {
+          if (!isDisabled) {
+            onSend?.();
+          }
+        }}
         disabled={isDisabled}
         className={cn(sendButtonVariants({ status }))}
-        aria-label="전송"
+        aria-label={status === CHAT_STATUS.LOADING ? '이동 중' : '전송'}
       >
-        <SendIcon className="size-[3.6rem]" />
+        {status === CHAT_STATUS.LOADING ? (
+          <span
+            aria-hidden
+            className={cn(
+              'size-8 shrink-0 rounded-full border-2 border-solid border-text-disable/40',
+              'border-t-text-default/55 motion-reduce:animate-none animate-spin',
+            )}
+          />
+        ) : (
+          <SendIcon className="size-[3.6rem]" />
+        )}
       </button>
     </div>
   );

--- a/src/components/common/Textfield/textfieldChatVariants.ts
+++ b/src/components/common/Textfield/textfieldChatVariants.ts
@@ -12,6 +12,7 @@ export const containerVariants = cva(
         default: '',
         disabled: '',
         error: 'border border-negative',
+        loading: '',
       },
     },
     defaultVariants: {
@@ -29,6 +30,7 @@ export const inputVariants = cva(
         default: 'text-text-default',
         disabled: 'placeholder:text-text-disable',
         error: 'text-negative placeholder:text-negative',
+        loading: 'placeholder:text-text-disable',
       },
     },
     defaultVariants: { status: 'default' },
@@ -41,6 +43,8 @@ export const sendButtonVariants = cva('cursor-pointer', {
       default: 'text-text-default',
       disabled: 'cursor-not-allowed text-icon-disabled',
       error: 'text-icon-disabled',
+      loading:
+        'flex size-[3.6rem] shrink-0 cursor-not-allowed items-center justify-center rounded-full bg-icon-disabled/40',
     },
   },
   defaultVariants: { status: 'default' },

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -2,7 +2,7 @@
 
 import { useQueryClient } from '@tanstack/react-query';
 import { useParams, useRouter } from 'next/navigation';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Header, HEADER_VARIANT, ReadumMarkLoadingIcon, TextfieldChat } from '@/components';
 import { CHAT_BG_VARIANT, CHAT_USER, type ChatMessage, PATH_NAME, QUERY_KEY } from '@/constants';
 import { useModal } from '@/hooks';
@@ -119,10 +119,7 @@ const Container = () => {
     isFetchingNextPage,
   } = useGetMessages(sessionId);
 
-  const historyChats: ChatMessage[] = useMemo(
-    () => mapInfinitePagesToHistoryChats(messagesData),
-    [messagesData],
-  );
+  const historyChats: ChatMessage[] = mapInfinitePagesToHistoryChats(messagesData);
 
   useEffect(() => {
     setNewChats((prev) => {
@@ -157,15 +154,9 @@ const Container = () => {
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingContent, setStreamingContent] = useState('');
 
-  const visiblePendingChats = useMemo(
-    () => stripPendingSyncedWithHistoryTail(historyChats, newChats),
-    [historyChats, newChats],
-  );
+  const visiblePendingChats = stripPendingSyncedWithHistoryTail(historyChats, newChats);
 
-  const allChats = useMemo(
-    () => [...historyChats, ...visiblePendingChats],
-    [historyChats, visiblePendingChats],
-  );
+  const allChats = [...historyChats, ...visiblePendingChats];
   const lastAIIndex = allChats.reduce(
     (last, chat, i) => (chat.user === CHAT_USER.AI ? i : last),
     -1,

--- a/src/components/pages/Chat/Modal.tsx
+++ b/src/components/pages/Chat/Modal.tsx
@@ -46,7 +46,7 @@ export const Modal = (props: Props) => {
   }, [isConfirming, isExiting, onCancel]);
 
   const handleExitAnimationEnd = useCallback(
-    (e: React.AnimationEvent<HTMLDialogElement>) => {
+    (e: React.AnimationEvent<HTMLDivElement>) => {
       if (e.target !== e.currentTarget) return;
       const { animationName } = e;
       if (typeof animationName !== 'string' || !animationName.includes('modal-sheet-exit')) {
@@ -76,14 +76,13 @@ export const Modal = (props: Props) => {
         )}
         onClick={dismissWithSlide}
       />
-      <dialog
-        open
+      <div
+        role="dialog"
         aria-modal="true"
         aria-labelledby="summary-modal-title"
         aria-describedby="summary-modal-description"
         className={cn(
-          'fixed top-1/2 left-1/2 z-modal m-0 flex max-h-[90dvh] min-w-0 w-[min(33rem,calc(100vw-4.8rem))] flex-col overflow-hidden rounded-[20px] border-none bg-text-white shadow-none',
-          'motion-reduce:animate-none motion-reduce:opacity-100 motion-reduce:[transform:translate(-50%,-50%)]',
+          'fixed inset-0 z-modal m-auto flex h-fit max-h-[90dvh] w-[min(33rem,calc(100vw-4.8rem))] flex-col overflow-hidden rounded-[20px] bg-text-white',
           isExiting ? 'animate-modal-sheet-exit' : 'animate-modal-sheet-enter',
         )}
         aria-busy={isConfirming ? true : undefined}
@@ -134,7 +133,7 @@ export const Modal = (props: Props) => {
             </Button>
           </footer>
         </div>
-      </dialog>
+      </div>
     </>,
     document.body,
   );

--- a/src/components/pages/Main/Footer.tsx
+++ b/src/components/pages/Main/Footer.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { BottomSheet, ChevronIcon, ListItem, TextfieldChat } from '@/components';
-import { PATH_NAME } from '@/constants';
+import { CHAT_STATUS, PATH_NAME } from '@/constants';
 import {
   cn,
   setLastSelectedUserBookIdClient,
@@ -29,6 +29,7 @@ export const MainFooter = (props: Props) => {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [collapsedCap, setCollapsedCap] = useState<string | undefined>(undefined);
   const [inputValue, setInputValue] = useState('');
+  const [isNavigatingToChat, setIsNavigatingToChat] = useState(false);
 
   const selectedBook = books.find((b) => b.userBookId === selectedUserBookId);
   const hasBooks = books.length > 0;
@@ -40,7 +41,8 @@ export const MainFooter = (props: Props) => {
 
   const handleSend = async () => {
     const trimmed = inputValue.trim();
-    if (!trimmed) return;
+    if (!trimmed || isNavigatingToChat) return;
+    setIsNavigatingToChat(true);
     setPendingMessage(trimmed);
     try {
       const data = await createSessionAsync(selectedUserBookId);
@@ -52,6 +54,7 @@ export const MainFooter = (props: Props) => {
       setLastSelectedUserBookIdClient(selectedUserBookId);
       router.push(PATH_NAME.chat.detail(String(data.sessionId)));
     } catch {
+      setIsNavigatingToChat(false);
       // 세션 생성 실패 시 상위(쿼리/토스트 등)에서 처리
     }
   };
@@ -187,6 +190,7 @@ export const MainFooter = (props: Props) => {
             role="presentation"
           >
             <TextfieldChat
+              status={isNavigatingToChat ? CHAT_STATUS.LOADING : CHAT_STATUS.DEFAULT}
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
               onSend={handleSend}

--- a/src/components/pages/Main/Footer.tsx
+++ b/src/components/pages/Main/Footer.tsx
@@ -32,6 +32,9 @@ export const MainFooter = (props: Props) => {
 
   const selectedBook = books.find((b) => b.userBookId === selectedUserBookId);
   const hasBooks = books.length > 0;
+  /** 한 권뿐이면 목록 선택·시트 오픈 불필요 — 내부 플래그와 무관하게 실제 노출 상태 */
+  const hasMultipleBooks = books.length > 1;
+  const sheetOpen = hasMultipleBooks && isSheetOpen;
 
   const setPendingMessage = usePendingChatStore((s) => s.set);
 
@@ -61,7 +64,7 @@ export const MainFooter = (props: Props) => {
     }
 
     const sync = () => {
-      if (isSheetOpen) {
+      if (sheetOpen) {
         return;
       }
       const h = el.offsetHeight;
@@ -107,10 +110,10 @@ export const MainFooter = (props: Props) => {
       cancelAnimationFrame(rafInner);
       ro.disconnect();
     };
-  }, [isSheetOpen]);
+  }, [sheetOpen]);
 
   const clickSection = () => {
-    if (!hasBooks) {
+    if (!hasBooks || !hasMultipleBooks) {
       return;
     }
     setIsSheetOpen((prev) => !prev);
@@ -118,7 +121,7 @@ export const MainFooter = (props: Props) => {
 
   return (
     <BottomSheet
-      open={hasBooks && isSheetOpen}
+      open={sheetOpen}
       collapsedMaxHeight={collapsedCap}
       onClose={() => {
         setIsSheetOpen(false);
@@ -128,31 +131,33 @@ export const MainFooter = (props: Props) => {
         className={cn(
           'grid min-h-0 min-w-0 max-h-full max-w-full flex-1 gap-y-0 overflow-hidden',
           'transition-[grid-template-rows] duration-680 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none',
-          isSheetOpen ? 'grid-rows-[auto_1fr]' : 'grid-rows-[auto_0fr]',
+          sheetOpen ? 'grid-rows-[auto_1fr]' : 'grid-rows-[auto_0fr]',
         )}
       >
         <div
           ref={peekRef}
           className={cn(
             'grid min-h-min min-w-0 grid-cols-1 gap-y-0 overflow-hidden',
-            isSheetOpen ? 'grid-rows-[auto_0fr]' : 'grid-rows-[auto_auto]',
+            sheetOpen ? 'grid-rows-[auto_0fr]' : 'grid-rows-[auto_auto]',
           )}
         >
-          {/* 버튼 레이아웃: 책 없으면 토글 숨김 · 시트 열기 비활성 */}
-          {hasBooks ? (
+          {/* 버튼 레이아웃: 책 2권 이상만 토글·시트 — 1권·0권은 정적 제목만 */}
+          {hasBooks && hasMultipleBooks ? (
             <button
               type="button"
               className={cn(
                 'flex min-h-0 min-w-0 shrink-0 cursor-pointer select-none items-center gap-[0.2rem] bg-white px-[2.4rem]',
-                isSheetOpen ? 'pt-[3.2rem] pb-[2.4rem]' : 'pt-[2.8rem]',
+                sheetOpen ? 'pt-[3.2rem] pb-[2.4rem]' : 'pt-[2.8rem]',
               )}
               onClick={clickSection}
             >
-              <p className="headline2-extrabold truncate text-text-default">{selectedBook?.title}</p>
+              <p className="headline2-extrabold truncate text-text-default">
+                {selectedBook?.title}
+              </p>
               <ChevronIcon
                 className={cn(
                   'size-8 fill-[#595C5C] transition-transform duration-680 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none',
-                  isSheetOpen ? 'rotate-0' : 'rotate-180',
+                  sheetOpen ? 'rotate-0' : 'rotate-180',
                 )}
               />
             </button>
@@ -164,7 +169,9 @@ export const MainFooter = (props: Props) => {
               )}
               role="presentation"
             >
-              <p className="headline2-extrabold truncate text-text-default">{selectedBook?.title}</p>
+              <p className="headline2-extrabold truncate text-text-default">
+                {selectedBook?.title}
+              </p>
             </div>
           )}
 
@@ -172,7 +179,7 @@ export const MainFooter = (props: Props) => {
           <div
             className={cn(
               'min-h-0 w-full overflow-hidden px-[2.4rem] pt-[1.8rem] pb-[max(2.4rem,env(safe-area-inset-bottom,0px))]',
-              isSheetOpen && 'hidden',
+              sheetOpen && 'hidden',
             )}
             onClick={(e) => {
               e.stopPropagation();
@@ -191,14 +198,14 @@ export const MainFooter = (props: Props) => {
         <div
           className={cn(
             'relative z-10 min-h-0 min-w-0 overflow-hidden',
-            isSheetOpen && 'bg-primary-white',
-            !isSheetOpen && 'pointer-events-none',
+            sheetOpen && 'bg-primary-white',
+            !sheetOpen && 'pointer-events-none',
           )}
         >
           <ul
             className={cn(
               'h-full min-h-0 min-w-0 max-w-full list-none overflow-x-hidden overflow-y-auto overscroll-contain bg-primary-white',
-              isSheetOpen ? 'pb-[max(2.4rem,env(safe-area-inset-bottom,0px))]' : 'pb-0',
+              sheetOpen ? 'pb-[max(2.4rem,env(safe-area-inset-bottom,0px))]' : 'pb-0',
             )}
           >
             {books.map((book) => (

--- a/src/components/pages/Main/MainBooksShell.tsx
+++ b/src/components/pages/Main/MainBooksShell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import {
   getLastSelectedUserBookIdClient,
   setLastSelectedUserBookIdClient,
@@ -19,16 +19,11 @@ export const MainBooksShell = (props: Props) => {
   const { books, initialSelectedUserBookId } = props;
   const { mutate: persistLastSelectedBook } = usePatchLastSelectedUserBook();
 
-  /** 시트에서 책 고를 때마다 증가 → useMemo가 sessionStorage를 다시 읽도록 */
-  const [selectionEpoch, setSelectionEpoch] = useState(0);
+  /** 시트에서 책 고를 때마다 증가해 리렌더 → sessionStorage 선택값 반영 */
+  const [, setSelectionEpoch] = useState(0);
 
-  const selectedUserBookId = useMemo(() => {
-    const fromClient = getLastSelectedUserBookIdClient(books);
-    if (fromClient !== undefined) {
-      return fromClient;
-    }
-    return initialSelectedUserBookId;
-  }, [books, initialSelectedUserBookId, selectionEpoch]);
+  const fromClient = getLastSelectedUserBookIdClient(books);
+  const selectedUserBookId = fromClient !== undefined ? fromClient : initialSelectedUserBookId;
 
   const handleSelectUserBook = (userBookId: number) => {
     setLastSelectedUserBookIdClient(userBookId);

--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Shelve } from '@/assets';
 import {
   CHAT_CARD_COLOR_SEQUENCE,
@@ -46,7 +46,7 @@ export const RecordsBody = (props: Props) => {
   const { mutateAsync: patchLastSelected } = usePatchLastSelectedUserBook();
   const containerRef = useRef<HTMLOListElement>(null);
   const { data, isPending } = useGetSessions(userBookId);
-  const sessions = useMemo(() => data?.sessions ?? [], [data?.sessions]);
+  const sessions = data?.sessions ?? [];
 
   useEffect(() => {
     const el = containerRef.current;

--- a/src/constants/textfieldChat.tsx
+++ b/src/constants/textfieldChat.tsx
@@ -2,6 +2,7 @@ export const CHAT_STATUS = {
   DEFAULT: 'default',
   DISABLED: 'disabled',
   ERROR: 'error',
+  LOADING: 'loading',
 } as const;
 
 export type chatStatus = (typeof CHAT_STATUS)[keyof typeof CHAT_STATUS];
@@ -17,4 +18,5 @@ export const CHAT_PLACEHOLDER = {
   [CHAT_STATUS.DEFAULT]: '오늘은 어떤 얘기를 해볼까요?',
   [CHAT_STATUS.DISABLED]: '연결을 확인해주세요',
   [CHAT_STATUS.ERROR]: '잘못된 입력',
+  [CHAT_STATUS.LOADING]: '채팅방으로 이동 중이에요…',
 } as const satisfies Record<chatStatus, string>;

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -300,15 +300,15 @@
   animation: toast-in 0.2s ease-out both;
 }
 
-/* 요약 마무리 모달: 화면 중앙 근처로 오며 시작은 아래에서 슬라이드 인 */
+/* 요약 마무리 모달: 아래에서 슬라이드 인 — 센터링은 inset-0 m-auto가 담당 */
 @keyframes modal-sheet-enter {
   from {
     opacity: 0;
-    transform: translate(-50%, calc(-50% + min(40vh, 28rem)));
+    transform: translateY(min(40vh, 28rem));
   }
   to {
     opacity: 1;
-    transform: translate(-50%, -50%);
+    transform: translateY(0);
   }
 }
 
@@ -320,11 +320,11 @@
 @keyframes modal-sheet-exit {
   from {
     opacity: 1;
-    transform: translate(-50%, -50%);
+    transform: translateY(0);
   }
   to {
     opacity: 0;
-    transform: translate(-50%, calc(-50% + min(40vh, 28rem)));
+    transform: translateY(min(40vh, 28rem));
   }
 }
 
@@ -336,13 +336,13 @@
   .animate-modal-sheet-enter {
     animation: none !important;
     opacity: 1 !important;
-    transform: translate(-50%, -50%) !important;
+    transform: none !important;
   }
 
   .animate-modal-sheet-exit {
     animation: none !important;
     opacity: 0 !important;
-    transform: translate(-50%, -50%) !important;
+    transform: none !important;
   }
 }
 


### PR DESCRIPTION
## 요약

요약 확인 모달 정렬 이슈, 메인 바텀시트 동작 개선, 메인 채팅 진입 로딩, ListItem 커버 플레이스홀더 등 QA 반영 묶음입니다.

## 변경 사항

- **요약 마무리 모달**: `<dialog>`/`transform`/`translate` 조합 문제를 피하기 위해 포털·레이아웃·키프레임 정리 후 PC·모바일에서 중앙 정렬 유지.
- **메인 푸터**: 책이 한 권일 때 책 선택 토글·바텀시트 미표시; `sheetOpen` 파생으로 레이아웃 안전 처리.
- **메인 대화 전송**: 세션 생성·이동 중 `CHAT_STATUS.LOADING`, 회색 버튼·스피너 및 입력 비활성화.
- **리스트 책 표지**: 알라딘 등 커버 없거나 로드 실패 시 회색 SVG 플레이스홀더; 플레이스홀더일 때 썸네일 블록에는 테두리·그림자 미적용.
- **경량 리팩터**: Chat/Main 관련 불필요한 `useMemo` 제거.

## 커밋

- \`fix: 모바일에서 요약 모달이 중앙에 표시되지 않는 문제 수정\`
- \`fix: 책 한 권일 때 메인 푸터 책 선택 토글·바텀시트 비활성화\`
- \`refactor: useMemo 정리 및 메인 대화 전송 로딩 UX\`
- \`feat: ListItem 썸네일 없음·실패 시 대체 이미지\`

## 체크리스트

- [ ] 로컬 기준 회귀(특히 채팅 요약 모달·메인 푸터·등록 검색 목록 표지).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이미지 로딩 실패 시 플레이스홀더 자동 표시
  * 채팅 전송 중 로딩 상태 표시 및 입력 필드 비활성화

* **버그 수정**
  * 이미지 로드 오류 처리 개선
  * 모달 다이얼로그 구조 및 동작 안정성 향상

* **스타일**
  * 모달 시트 진입/종료 애니메이션 개선
  * 채팅 입력 필드 로딩 상태 시각 피드백 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team4-web/pull/105)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->