### PR TITLE
[FIX] 홈 채팅목록 QA 수정 및 무한스크롤 적용

### DIFF
--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -110,6 +110,7 @@ export const RecordsBody = (props: Props) => {
                       status={SESSION_STATUS_TO_CARD[session.status]}
                       date={formatDate(session.lastChattedDate)}
                       summary={session.title}
+                      bookmarked={session.status === 'CLOSED'}
                     />
                   </Link>
                 </li>

--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -44,7 +44,6 @@ export const RecordsBody = (props: Props) => {
   const { userBookId } = props;
   const router = useRouter();
   const { mutateAsync: patchLastSelected } = usePatchLastSelectedUserBook();
-  const containerRef = useRef<HTMLOListElement>(null);
   const bottomSentinelRef = useRef<HTMLDivElement>(null);
 
   const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -94,7 +93,6 @@ export const RecordsBody = (props: Props) => {
         <>
           <div className="flex-1" />
           <ol
-            ref={containerRef}
             className="relative flex list-none flex-col overflow-y-auto py-[6.4rem]"
           >
           {sessions.map((session, index) => {

--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -49,10 +49,8 @@ export const RecordsBody = (props: Props) => {
   const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGetSessions(userBookId);
 
-  // 최신순(newest-first) 그대로 표시 — 위가 최신, 아래가 오래된 순
   const sessions = (data?.pages ?? []).flatMap((page) => page.sessions);
 
-  // 아래로 스크롤 시 오래된 세션 추가 로드
   useEffect(() => {
     const sentinel = bottomSentinelRef.current;
     if (!sentinel) return;
@@ -115,7 +113,6 @@ export const RecordsBody = (props: Props) => {
                     try {
                       await patchLastSelected(userBookId);
                     } catch {
-                      // 서버 반영 실패해도 이동·클라이언트 선택값은 유지
                     }
                     setLastSelectedUserBookIdClient(userBookId);
                     router.push(path);

--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -101,7 +101,7 @@ export const RecordsBody = (props: Props) => {
             const sessionIdStr = String(session.sessionId);
             const color =
               CHAT_CARD_COLOR_SEQUENCE[
-                (sessions.length - 1 - index) % CHAT_CARD_COLOR_SEQUENCE.length
+                CHAT_CARD_COLOR_SEQUENCE.length - 1 - (index % CHAT_CARD_COLOR_SEQUENCE.length)
               ];
             const path =
               session.status === 'CLOSED' || session.status === 'SUMMARIZING'

--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -44,7 +44,7 @@ export const RecordsBody = (props: Props) => {
   const { userBookId } = props;
   const router = useRouter();
   const { mutateAsync: patchLastSelected } = usePatchLastSelectedUserBook();
-  const bottomSentinelRef = useRef<HTMLDivElement>(null);
+  const bottomSentinelRef = useRef<HTMLLIElement>(null);
 
   const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGetSessions(userBookId);
@@ -126,7 +126,7 @@ export const RecordsBody = (props: Props) => {
                 </li>
               );
             })}
-            <div ref={bottomSentinelRef} />
+            <li ref={bottomSentinelRef} aria-hidden />
           </ol>
         </>
       )}

--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -45,13 +45,31 @@ export const RecordsBody = (props: Props) => {
   const router = useRouter();
   const { mutateAsync: patchLastSelected } = usePatchLastSelectedUserBook();
   const containerRef = useRef<HTMLOListElement>(null);
-  const { data, isPending } = useGetSessions(userBookId);
-  const sessions = data?.sessions ?? [];
+  const bottomSentinelRef = useRef<HTMLDivElement>(null);
 
+  const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useGetSessions(userBookId);
+
+  // 최신순(newest-first) 그대로 표시 — 위가 최신, 아래가 오래된 순
+  const sessions = (data?.pages ?? []).flatMap((page) => page.sessions);
+
+  // 아래로 스크롤 시 오래된 세션 추가 로드
   useEffect(() => {
-    const el = containerRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [sessions]);
+    const sentinel = bottomSentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const isEmpty = !isPending && sessions.length === 0;
 
@@ -79,43 +97,44 @@ export const RecordsBody = (props: Props) => {
             ref={containerRef}
             className="relative flex list-none flex-col overflow-y-auto py-[6.4rem]"
           >
-            {sessions.map((session, index) => {
-              const sessionIdStr = String(session.sessionId);
-              const color =
-                CHAT_CARD_COLOR_SEQUENCE[
-                  (sessions.length - 1 - index) % CHAT_CARD_COLOR_SEQUENCE.length
-                ];
-              const path =
-                session.status === 'CLOSED' || session.status === 'SUMMARIZING'
-                  ? `${PATH_NAME.summary.detail(sessionIdStr)}?color=${color}`
-                  : PATH_NAME.chat.detail(sessionIdStr);
+          {sessions.map((session, index) => {
+            const sessionIdStr = String(session.sessionId);
+            const color =
+              CHAT_CARD_COLOR_SEQUENCE[
+                (sessions.length - 1 - index) % CHAT_CARD_COLOR_SEQUENCE.length
+              ];
+            const path =
+              session.status === 'CLOSED' || session.status === 'SUMMARIZING'
+                ? `${PATH_NAME.summary.detail(sessionIdStr)}?color=${color}`
+                : PATH_NAME.chat.detail(sessionIdStr);
 
-              return (
-                <li key={session.sessionId} className="mb-[-6.4rem]">
-                  <Link
-                    href={path}
-                    onClick={async (e) => {
-                      e.preventDefault();
-                      try {
-                        await patchLastSelected(userBookId);
-                      } catch {
-                        // 서버 반영 실패해도 이동·클라이언트 선택값은 유지
-                      }
-                      setLastSelectedUserBookIdClient(userBookId);
-                      router.push(path);
-                    }}
-                  >
-                    <ChatCard
-                      color={color}
-                      status={SESSION_STATUS_TO_CARD[session.status]}
-                      date={formatDate(session.lastChattedDate)}
-                      summary={session.title}
-                      bookmarked={session.status === 'CLOSED'}
-                    />
-                  </Link>
-                </li>
-              );
-            })}
+            return (
+              <li key={session.sessionId} className="mb-[-6.4rem]">
+                <Link
+                  href={path}
+                  onClick={async (e) => {
+                    e.preventDefault();
+                    try {
+                      await patchLastSelected(userBookId);
+                    } catch {
+                      // 서버 반영 실패해도 이동·클라이언트 선택값은 유지
+                    }
+                    setLastSelectedUserBookIdClient(userBookId);
+                    router.push(path);
+                  }}
+                >
+                  <ChatCard
+                    color={color}
+                    status={SESSION_STATUS_TO_CARD[session.status]}
+                    date={formatDate(session.lastChattedDate)}
+                    summary={session.title}
+                    bookmarked={session.status === 'CLOSED'}
+                  />
+                </Link>
+              </li>
+            );
+          })}
+          <div ref={bottomSentinelRef} />
           </ol>
         </>
       )}

--- a/src/components/pages/Main/RecordsBody.tsx
+++ b/src/components/pages/Main/RecordsBody.tsx
@@ -90,46 +90,43 @@ export const RecordsBody = (props: Props) => {
       ) : (
         <>
           <div className="flex-1" />
-          <ol
-            className="relative flex list-none flex-col overflow-y-auto py-[6.4rem]"
-          >
-          {sessions.map((session, index) => {
-            const sessionIdStr = String(session.sessionId);
-            const color =
-              CHAT_CARD_COLOR_SEQUENCE[
-                CHAT_CARD_COLOR_SEQUENCE.length - 1 - (index % CHAT_CARD_COLOR_SEQUENCE.length)
-              ];
-            const path =
-              session.status === 'CLOSED' || session.status === 'SUMMARIZING'
-                ? `${PATH_NAME.summary.detail(sessionIdStr)}?color=${color}`
-                : PATH_NAME.chat.detail(sessionIdStr);
+          <ol className="relative flex list-none flex-col overflow-y-auto py-[6.4rem]">
+            {sessions.map((session, index) => {
+              const sessionIdStr = String(session.sessionId);
+              const color =
+                CHAT_CARD_COLOR_SEQUENCE[
+                  CHAT_CARD_COLOR_SEQUENCE.length - 1 - (index % CHAT_CARD_COLOR_SEQUENCE.length)
+                ];
+              const path =
+                session.status === 'CLOSED' || session.status === 'SUMMARIZING'
+                  ? `${PATH_NAME.summary.detail(sessionIdStr)}?color=${color}`
+                  : PATH_NAME.chat.detail(sessionIdStr);
 
-            return (
-              <li key={session.sessionId} className="mb-[-6.4rem]">
-                <Link
-                  href={path}
-                  onClick={async (e) => {
-                    e.preventDefault();
-                    try {
-                      await patchLastSelected(userBookId);
-                    } catch {
-                    }
-                    setLastSelectedUserBookIdClient(userBookId);
-                    router.push(path);
-                  }}
-                >
-                  <ChatCard
-                    color={color}
-                    status={SESSION_STATUS_TO_CARD[session.status]}
-                    date={formatDate(session.lastChattedDate)}
-                    summary={session.title}
-                    bookmarked={session.status === 'CLOSED'}
-                  />
-                </Link>
-              </li>
-            );
-          })}
-          <div ref={bottomSentinelRef} />
+              return (
+                <li key={session.sessionId} className="mb-[-6.4rem]">
+                  <Link
+                    href={path}
+                    onClick={async (e) => {
+                      e.preventDefault();
+                      try {
+                        await patchLastSelected(userBookId);
+                      } catch {}
+                      setLastSelectedUserBookIdClient(userBookId);
+                      router.push(path);
+                    }}
+                  >
+                    <ChatCard
+                      color={color}
+                      status={SESSION_STATUS_TO_CARD[session.status]}
+                      date={formatDate(session.lastChattedDate)}
+                      summary={session.title}
+                      bookmarked={session.status === 'CLOSED'}
+                    />
+                  </Link>
+                </li>
+              );
+            })}
+            <div ref={bottomSentinelRef} />
           </ol>
         </>
       )}

--- a/src/components/pages/Summary/SummaryHeader.tsx
+++ b/src/components/pages/Summary/SummaryHeader.tsx
@@ -2,8 +2,9 @@
 
 import { useRouter } from 'next/navigation';
 import { Header, HEADER_VARIANT } from '@/components';
+import { PATH_NAME } from '@/constants';
 
 export const SummaryHeader = () => {
   const router = useRouter();
-  return <Header variant={HEADER_VARIANT.BACK} onBack={() => router.back()} />;
+  return <Header variant={HEADER_VARIANT.BACK} onBack={() => router.push(PATH_NAME.main())} />;
 };

--- a/src/lib/api/services/ai-chat/ai-chat.service.ts
+++ b/src/lib/api/services/ai-chat/ai-chat.service.ts
@@ -1,15 +1,18 @@
 'use client';
 
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { QUERY_KEY } from '@/constants';
 import { createSession, getSessions } from './ai-chat.client';
 
-const SESSION_PAGE_SIZE = 50;
+const SESSION_PAGE_SIZE = 7;
 
 export const useGetSessions = (userBookId: number) => {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: QUERY_KEY.aiChat.sessions(userBookId),
-    queryFn: () => getSessions({ userBookId, page: 1, size: SESSION_PAGE_SIZE }),
+    queryFn: ({ pageParam }) =>
+      getSessions({ userBookId, page: pageParam as number, size: SESSION_PAGE_SIZE }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     staleTime: 0,
   });
 };

--- a/src/lib/api/services/ai-chat/ai-chat.service.ts
+++ b/src/lib/api/services/ai-chat/ai-chat.service.ts
@@ -10,6 +10,7 @@ export const useGetSessions = (userBookId: number) => {
   return useQuery({
     queryKey: QUERY_KEY.aiChat.sessions(userBookId),
     queryFn: () => getSessions({ userBookId, page: 1, size: SESSION_PAGE_SIZE }),
+    staleTime: 0,
   });
 };
 

--- a/src/lib/api/services/ai-chat/ai-chat.service.ts
+++ b/src/lib/api/services/ai-chat/ai-chat.service.ts
@@ -1,16 +1,23 @@
 'use client';
 
-import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
+import { type InfiniteData, useInfiniteQuery, useMutation } from '@tanstack/react-query';
+import { type SessionListData } from './ai-chat.type';
 import { QUERY_KEY } from '@/constants';
 import { createSession, getSessions } from './ai-chat.client';
 
 const SESSION_PAGE_SIZE = 7;
 
 export const useGetSessions = (userBookId: number) => {
-  return useInfiniteQuery({
+  return useInfiniteQuery<
+    SessionListData,
+    Error,
+    InfiniteData<SessionListData>,
+    ReturnType<typeof QUERY_KEY.aiChat.sessions>,
+    number
+  >({
     queryKey: QUERY_KEY.aiChat.sessions(userBookId),
     queryFn: ({ pageParam }) =>
-      getSessions({ userBookId, page: pageParam as number, size: SESSION_PAGE_SIZE }),
+      getSessions({ userBookId, page: pageParam, size: SESSION_PAGE_SIZE }),
     initialPageParam: 1,
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     staleTime: 0,


### PR DESCRIPTION
## 📌 PR 제목

[QA] 홈 채팅목록 QA 수정 및 무한스크롤 적용

---

## 🔗 관련 이슈 (Issue)

- Closes #106

---

## ✅ 작업 내용

홈 화면 채팅목록 관련 QA 수정 사항 4건을 반영했습니다.

- **북마크 아이콘 미표시 수정**: 요약 완료(CLOSED) 상태 세션에 bookmarked prop을 전달하도록 수정 (RecordsBody.tsx)
- **뒤로가기 라우팅 수정**: 요약 완료 후 뒤로가기 시 채팅창 대신 홈(/)으로 이동하도록 수정 (SummaryHeader.tsx)
- **세션 목록 캐시 문제 수정**: 홈 복귀 시 항상 최신 데이터를 가져오도록 staleTime: 0 적용 (ai-chat.service.ts)
- **무한스크롤 적용**: useQuery → useInfiniteQuery로 전환, 최신순 정렬 상태에서 아래로 스크롤 시 오래된 세션 7개씩 추가 로드 (RecordsBody.tsx, ai-chat.service.ts)

---

## 🖥️ 테스트 방법

1. 홈 화면 진입
2. 요약 완료된 채팅 카드에 북마크 아이콘이 표시되는지 확인
3. 채팅 → 요약하기 완료 후 뒤로가기 시 홈으로 이동하는지 확인
4. 채팅 후 홈으로 돌아왔을 때 새로고침 없이 목록에 반영되는지 확인
5. 세션이 7개 초과일 때 아래로 스크롤 시 추가 세션이 로드되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 세션 목록에 무한 스크롤 기능 추가

* **개선 사항**
  * 세션 상세 페이지에서 뒤로가기 시 메인 페이지로 이동하도록 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team4-web/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->