### PR TITLE
[FEAT] TabView 공통 컴포넌트 추가, /mypage 페이지에 테스트로 추가

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,15 @@
+import { type Metadata } from 'next';
+import { MypageContainer } from '@/components';
+
+export const generateMetadata = async (): Promise<Metadata> => {
+  return {
+    title: 'Readum:마이페이지',
+    description: 'Readum:사유하는 독서가인 당신을 위해',
+  };
+};
+
+const page = () => {
+  return <MypageContainer />;
+};
+
+export default page;

--- a/src/components/common/TabView/TabView.stories.tsx
+++ b/src/components/common/TabView/TabView.stories.tsx
@@ -1,0 +1,34 @@
+import { type Meta, type StoryObj } from '@storybook/nextjs-vite';
+import { TabView } from '@/components';
+
+const meta = {
+  title: 'Common/TabView',
+  component: TabView,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof TabView>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Panel = (props: { children: string }) => (
+  <div className="body1-medium px-[2.4rem] py-[3.2rem] text-text-default">{props.children}</div>
+);
+
+export const Default: Story = {
+  args: {
+    defaultValue: 'registered',
+    tabs: [
+      {
+        value: 'registered',
+        label: '등록된 책',
+        count: 13,
+        content: <Panel>등록된 책 콘텐츠</Panel>,
+      },
+      { value: 'records', label: '감상 기록', count: 24, content: <Panel>감상 기록 콘텐츠</Panel> },
+    ],
+  },
+};

--- a/src/components/common/TabView/TabView.tsx
+++ b/src/components/common/TabView/TabView.tsx
@@ -11,7 +11,7 @@ export type TabItem = {
   content: ReactNode;
 };
 
-export type TabViewProps = {
+type Props = {
   tabs: TabItem[];
   value?: string;
   defaultValue?: string;
@@ -28,7 +28,7 @@ export type TabViewProps = {
  *
  * `onValueChange` 등 함수 prop은 클라이언트 컴포넌트에서만 전달할 수 있다.
  */
-export const TabView = (props: TabViewProps) => {
+export const TabView = (props: Props) => {
   const { tabs, value, defaultValue, onValueChange, className } = props;
 
   const baseId = useId();

--- a/src/components/common/TabView/TabView.tsx
+++ b/src/components/common/TabView/TabView.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { type KeyboardEvent, type ReactNode, useId, useRef, useState } from 'react';
+import { cn } from '@/lib';
+import { tabTriggerLabelVariants, tabTriggerVariants } from './tabViewVariants';
+
+export type TabItem = {
+  value: string;
+  label: string;
+  count?: number;
+  content: ReactNode;
+};
+
+export type TabViewProps = {
+  tabs: TabItem[];
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  className?: string;
+};
+
+/**
+ * 탭 헤더와 선택된 탭의 콘텐츠를 함께 렌더하는 공통 탭 컴포넌트.
+ *
+ * `tabs` config 배열로 각 탭의 라벨/카운트/패널 콘텐츠를 전달한다.
+ * controlled(`value`) / uncontrolled(`defaultValue`) 모두 지원하며,
+ * 좌/우 화살표 키로 탭 간 이동이 가능하다(ARIA Tabs 패턴).
+ *
+ * `onValueChange` 등 함수 prop은 클라이언트 컴포넌트에서만 전달할 수 있다.
+ */
+export const TabView = (props: TabViewProps) => {
+  const { tabs, value, defaultValue, onValueChange, className } = props;
+
+  const baseId = useId();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const isControlled = value !== undefined;
+  const hasValue = (target?: string) =>
+    target !== undefined && tabs.some((t) => t.value === target);
+  const initialValue = hasValue(defaultValue) ? (defaultValue as string) : tabs[0]?.value;
+  const [internalValue, setInternalValue] = useState(initialValue);
+
+  if (tabs.length === 0) {
+    console.error('TabView: `tabs`가 비어 있습니다. 최소 1개 이상의 탭이 필요합니다.');
+    return null;
+  }
+
+  const rawValue = isControlled ? value : internalValue;
+  const selectedValue = hasValue(rawValue) ? (rawValue as string) : tabs[0].value;
+  const selectedIndex = tabs.findIndex((t) => t.value === selectedValue);
+  const activeTab = tabs[selectedIndex];
+
+  const selectTab = (next: string) => {
+    if (!isControlled) {
+      setInternalValue(next);
+    }
+    onValueChange?.(next);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') {
+      return;
+    }
+    e.preventDefault();
+    const direction = e.key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (selectedIndex + direction + tabs.length) % tabs.length;
+    selectTab(tabs[nextIndex].value);
+    tabRefs.current[nextIndex]?.focus();
+  };
+
+  const tabId = (tabValue: string) => `${baseId}-tab-${tabValue}`;
+  const panelId = (tabValue: string) => `${baseId}-panel-${tabValue}`;
+
+  return (
+    <div className={cn('flex w-full flex-col', className)}>
+      <div role="tablist" className="flex w-full justify-center px-[2.4rem]">
+        {tabs.map((tab, index) => {
+          const isActiveTab = tab.value === selectedValue;
+
+          return (
+            <button
+              key={tab.value}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              type="button"
+              role="tab"
+              id={tabId(tab.value)}
+              aria-selected={isActiveTab}
+              aria-controls={panelId(tab.value)}
+              tabIndex={isActiveTab ? 0 : -1}
+              className={cn(tabTriggerVariants({ active: isActiveTab }))}
+              onClick={() => selectTab(tab.value)}
+              onKeyDown={handleKeyDown}
+            >
+              <span className={cn(tabTriggerLabelVariants({ active: isActiveTab }))}>
+                {tab.label}
+              </span>
+              {tab.count !== undefined && (
+                <span className="body1-extrabold text-text-default">{tab.count}</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div role="tabpanel" id={panelId(activeTab.value)} aria-labelledby={tabId(activeTab.value)}>
+        {activeTab.content}
+      </div>
+    </div>
+  );
+};

--- a/src/components/common/TabView/index.ts
+++ b/src/components/common/TabView/index.ts
@@ -1,1 +1,1 @@
-export { type TabItem, TabView, type TabViewProps } from './TabView';
+export { type TabItem, TabView } from './TabView';

--- a/src/components/common/TabView/index.ts
+++ b/src/components/common/TabView/index.ts
@@ -1,0 +1,1 @@
+export { type TabItem, TabView, type TabViewProps } from './TabView';

--- a/src/components/common/TabView/tabViewVariants.ts
+++ b/src/components/common/TabView/tabViewVariants.ts
@@ -1,0 +1,24 @@
+import { cva } from 'class-variance-authority';
+
+export const tabTriggerVariants = cva(
+  'flex min-w-0 flex-1 cursor-pointer items-center justify-center gap-[0.6rem] border-b-[0.14rem] py-[1.2rem] outline-none',
+  {
+    variants: {
+      active: {
+        true: 'border-icon-secondary',
+        false: 'border-transparent',
+      },
+    },
+    defaultVariants: { active: false },
+  },
+);
+
+export const tabTriggerLabelVariants = cva('body1-medium whitespace-nowrap', {
+  variants: {
+    active: {
+      true: 'text-text-default',
+      false: 'text-text-caption',
+    },
+  },
+  defaultVariants: { active: false },
+});

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -7,6 +7,7 @@ export * from './Header';
 export * from './Icon';
 export * from './ListItem';
 export * from './Loading';
+export * from './TabView';
 export * from './Textfield';
 export * from './Toast';
 export * from './Tooltip';

--- a/src/components/pages/Mypage/Container.tsx
+++ b/src/components/pages/Mypage/Container.tsx
@@ -1,0 +1,29 @@
+import { TabView } from '@/components';
+
+const Panel = (props: { children: string }) => (
+  <div className="body1-medium px-[2.4rem] py-[4rem] text-text-default">{props.children}</div>
+);
+
+export const MypageContainer = () => {
+  return (
+    <div className="flex min-h-dvh flex-col">
+      <TabView
+        defaultValue="registered"
+        tabs={[
+          {
+            value: 'registered',
+            label: '등록된 책',
+            count: 13,
+            content: <Panel>등록된 책 콘텐츠</Panel>,
+          },
+          {
+            value: 'records',
+            label: '감상 기록',
+            count: 24,
+            content: <Panel>감상 기록 콘텐츠</Panel>,
+          },
+        ]}
+      />
+    </div>
+  );
+};

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -1,6 +1,7 @@
 export { Chat } from './Chat/Chat';
 export { default as ChatContainer } from './Chat/Container';
 export { MainContainer } from './Main/Container';
+export { MypageContainer } from './Mypage/Container';
 export { RegisterComplete } from './Register/Complete';
 export { RegisterContainer } from './Register/Container';
 export { SummaryContainer } from './Summary/Container';

--- a/src/constants/pathName.ts
+++ b/src/constants/pathName.ts
@@ -14,4 +14,6 @@ export const PATH_NAME = {
   summary: {
     detail: (summaryId: string) => `/summary/${summaryId}`,
   },
+
+  mypage: () => '/mypage',
 } as const;

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -233,6 +233,13 @@
   font-weight: 700;
 }
 
+@utility body1-extrabold {
+  font-family: var(--font-sans);
+  font-size: var(--text-body1);
+  line-height: var(--leading-body1);
+  font-weight: 800;
+}
+
 @utility body2-medium {
   font-family: var(--font-sans);
   font-size: var(--text-body2);


### PR DESCRIPTION
## 📌 PR 제목

[FEAT] TabView 공통 컴포넌트 추가 및 mypage 테스트 페이지 배치

---

## 🔗 관련 이슈 (Issue)

- Closes #113

---

## ✅ 작업 내용

선택한 탭에 따라 하단 콘텐츠가 전환되는 공통 `TabView` 컴포넌트를 추가했습니다. 기존 공통 컴포넌트의 콘텐츠 전달 패턴(Tooltip의 `content: ReactNode` prop)을 배열로 확장한 **config 기반 API**(`tabs` prop)로 설계했습니다.

- `TabView` 컴포넌트 추가 (`components/common/TabView/`)
  - `tabs` config 배열로 각 탭의 `label` / `count` / `content` 전달
  - controlled(`value`) / uncontrolled(`defaultValue`) 모두 지원
  - 활성 탭만 밑줄(`border-icon-secondary`) + 라벨 색 분기(활성 `text-default` / 비활성 `text-caption`), 카운트는 항상 `text-default`
  - `role=tablist/tab/tabpanel` + `aria-selected`/`aria-controls` 접근성 속성 부여, 좌/우 화살표 키로 탭 이동(ARIA Tabs 패턴)
  - 비선택 탭 패널은 unmount, 빈 `tabs`/잘못된 `value`에 대한 fallback 처리
  - cva 변형 분리(`tabViewVariants.ts`), Storybook `Default` 스토리 추가
- 디자인의 ExtraBold(800) 카운트를 위해 `body1-extrabold` 타이포 유틸리티 추가 (`style/global.css`)
- TabView 동작 확인용 `/mypage` 라우트 및 빈 페이지 배치
  - `app/mypage/page.tsx` (thin 페이지) + `components/pages/Mypage/Container.tsx` (Container)
  - `PATH_NAME.mypage`, 공통/페이지 barrel export 추가

### Server/Client 경계

- `TabView.tsx`는 상태/키보드 핸들링을 위한 Client 컴포넌트입니다.
- `mypage/page.tsx`, `Mypage/Container.tsx`는 서버 컴포넌트로 유지되며, 플레이스홀더 콘텐츠만 TabView에 주입합니다.

### 스크린샷

|내용|스크린샷|비고|
|---|---|---|
| Figma 디자인 | <img width="425" height="210" alt="image" src="https://github.com/user-attachments/assets/ab51fb86-60c9-42b9-8c1b-ab60afe9ab73" /> | . |
| 구현 디자인<br />임시: `/mypage` 내부 | <img width="371" height="207" alt="image" src="https://github.com/user-attachments/assets/138e34fb-d9bb-460d-ba40-e7b0235e0412" /> | Storybook이 로컬에서 안 뜨는 별도 이슈 발생<br /> 임시로 `/mypage` 빈 페이지 추가 후 위치시킴 |

---

## 🖥️ 테스트 방법

1. `pnpm dev` 실행 후 `http://localhost:3000/mypage` 접속
2. "등록된 책 13" / "감상 기록 24" 두 탭이 보이는지 확인
3. 탭 클릭 또는 좌/우 화살표 키로 선택 전환 시 하단 콘텐츠가 "등록된 책 콘텐츠" ↔ "감상 기록 콘텐츠"로 바뀌는지 확인
4. 활성 탭에만 하단 밑줄이 표시되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 마이페이지 화면 추가(동적 메타데이터 지원)
  * 탭 네비게이션 컴포넌트 추가(등록/기록 탭, 기본 선택값 지원)
  * 라우트에 마이페이지 경로 추가

* **Accessibility / Interaction**
  * 키보드 네비게이션 지원(좌/우 화살표로 탭 이동, 포커스 관리, ARIA 적용)

* **Style**
  * 새로운 텍스트 스타일 유틸리티 추가

* **Documentation**
  * 탭 컴포넌트용 데모(스토리) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->