### PR TITLE
[FIX] 레이아웃 444px 조건부 반응형 너비 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,8 +26,8 @@ const RootLayout = (props: Props): React.ReactElement => {
 
   return (
     <html lang="ko" className={`${suit.variable} antialiased`}>
-      <body className="min-h-dvh bg-gray-50">
-        <main className="relative mx-auto min-h-dvh w-full max-w-150 overflow-x-hidden bg-primary-base">
+      <body className="min-h-dvh bg-gray-10">
+        <main className="relative mx-auto min-h-dvh w-full max-w-mobile-responsive overflow-x-hidden bg-primary-base">
           <div className="relative">
             <QueryProvider>
               <PageTransition>{children}</PageTransition>

--- a/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.tsx
@@ -70,7 +70,7 @@ export const BottomSheet = (props: BottomSheetProps) => {
   return createPortal(
     <div
       className={cn(
-        'pointer-events-none fixed bottom-0 left-1/2 top-0 z-50 w-full max-w-150 -translate-x-1/2 overflow-x-hidden',
+        'pointer-events-none fixed bottom-0 left-1/2 top-0 z-50 w-full max-w-mobile-responsive -translate-x-1/2 overflow-x-hidden',
       )}
       data-state={open ? 'open' : 'closed'}
     >

--- a/src/components/common/Toast/ToastContainer.tsx
+++ b/src/components/common/Toast/ToastContainer.tsx
@@ -25,7 +25,7 @@ export const ToastContainer = () => {
   const toasts = useToastStore((s) => s.toasts);
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 top-0 z-50 mx-auto flex w-full max-w-150 flex-col items-center gap-[0.8rem] px-[2.4rem] pt-[2.4rem]">
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-50 mx-auto flex w-full max-w-mobile-responsive flex-col items-center gap-[0.8rem] px-[2.4rem] pt-[2.4rem]">
       {toasts.map((toast) => (
         <div key={toast.id} className="pointer-events-auto w-full flex justify-center">
           <ToastTimer id={toast.id} duration={toast.duration} />

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -389,6 +389,14 @@
   }
 }
 
+@utility max-w-mobile-responsive {
+  max-width: none;
+
+  @media (width > 444px) {
+    max-width: 37.5rem; /* 375px (1rem = 10px) */
+  }
+}
+
 @layer utilities {
   .scrollbar-hide {
     /* IE and Edge */


### PR DESCRIPTION
## 📌 PR 제목

[FIX] 레이아웃 444px 조건부 반응형 너비 적용

---

## 🔗 관련 이슈 (Issue)

- Closes #128

---

## ✅ 작업 내용

전역 컨테이너가 `max-w-150`(375px)로 **고정**되어, 고해상도 모바일(아이폰 12/14 Pro 등, 390~430px)에서 컨테이너 좌우에 `<body>` 배경(회색)이 노출되던 문제를 수정했습니다.

- `global.css`: `max-w-mobile-responsive` 유틸리티 추가 — **444px 이하**는 제한 없이 `w-full`, **444px 초과**는 375px로 고정
  - `@layer utilities` raw 방식은 base/미디어쿼리 규칙의 출력 순서가 보장되지 않아, 순서 보존을 위해 `@utility`로 정의
- `layout.tsx` / `ToastContainer.tsx` / `BottomSheet.tsx`: `max-w-150` → `max-w-mobile-responsive` 교체
- `layout.tsx`: 데스크톱에서 컨테이너 밖 `<body>` 배경 `bg-gray-50` → `bg-gray-10`

### 스크린샷

|내용|스크린샷|
|---|---|
| As-is | <img width="357" height="780" alt="image" src="https://github.com/user-attachments/assets/871469c6-52d0-49cd-953d-2e44c5d7d5c3" /> |
| To-be | <img width="357" height="780" alt="image" src="https://github.com/user-attachments/assets/d88cbbec-b0c3-4f6b-8f05-1b1666a4189b" /> |

---

## 🖥️ 테스트 방법

1. 모바일(390~430px)로 접속 → 좌우 회색 마진 없이 화면을 꽉 채우는지 확인
2. 데스크톱(444px 초과)에서 컨테이너가 375px로 가운데 정렬되는지 확인
3. Toast / BottomSheet가 본문과 동일한 폭·정렬로 표시되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일

* 배경색이 조정되었습니다.
* 모바일 반응형 레이아웃이 개선되어 다양한 화면 크기에서 더 나은 사용자 경험을 제공합니다.
* 컴포넌트의 너비 제약 조건이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->