### PR TITLE
[FIX] 존재하지 않는 PATCH /users/me 요청 임시 중단

### DIFF
--- a/src/lib/api/services/users/users.client.ts
+++ b/src/lib/api/services/users/users.client.ts
@@ -1,12 +1,13 @@
-import { ENDPOINTS } from '@/constants';
-import { publicHttp } from '@/lib';
+// import { ENDPOINTS } from '@/constants';
+// import { publicHttp } from '@/lib';
 
 export type PatchLastSelectedUserBookRequest = {
   lastSelectedUserBookId: number;
 };
 
 export const patchLastSelectedUserBookId = async (userBookId: number) => {
-  await publicHttp.patch<PatchLastSelectedUserBookRequest, unknown>(ENDPOINTS.USERS.me(), {
-    lastSelectedUserBookId: userBookId,
-  });
+  // TODO: 백엔드에서 lastSelectedUserBookId를 PATCH할 수 있는 API를 제공 시 다시 연결한다.
+  // await publicHttp.patch<PatchLastSelectedUserBookRequest, unknown>(ENDPOINTS.USERS.me(), {
+  //   lastSelectedUserBookId: userBookId,
+  // });
 };


### PR DESCRIPTION
## 📌 PR 제목

> [FIX] 존재하지 않는 PATCH /users/me 요청 중단

---

## 🔗 관련 이슈 (Issue)

- Closes #134

---

## ✅ 작업 내용

- Swagger 기준 제공되지 않는 `PATCH /api/v1/users/me` 요청을 임시 no-op 처리했습니다. (`src/lib/api/services/users/users.client.ts`)
- 기존 `lastSelectedUserBookId` 동기화 코드는 주석으로 남기고, 백엔드 저장 API 제공 시 복구할 수 있도록 TODO를 추가했습니다.
- 대화 세션 진입 및 `AI와 대화하기` 클릭 시 발생하던 불필요한 500 에러 요청을 중단했습니다.

---

## 🖥️ 테스트 방법

1. 메인 화면에서 기존 대화 세션에 진입합니다.
2. `AI와 대화하기` 버튼을 클릭해 새 대화 세션에 진입합니다.
3. 두 경로에서 `PATCH /api/v1/users/me` 요청이 발생하지 않는지 확인합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **작업 진행 중**
  * 사용자 선택 도서 정보 동기화 기능이 일시 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->