### PR TITLE
[CHORE] main 릴리즈 자동화 워크플로우 추가

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -1,0 +1,162 @@
+name: Release Create
+
+# main으로 PR이 병합되면 release:* label에 따라 GitHub Release와 태그를 생성한다.
+# workflow_dispatch로 수동 보정(버전 고정/재시도)도 가능하다.
+# 자세한 정책은 docs/plans/main-release-workflow.md 참조.
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. v1.2.3'
+        required: true
+        type: string
+      target:
+        description: 'Target branch, tag, or SHA'
+        required: false
+        default: main
+        type: string
+      prerelease:
+        description: 'Mark as prerelease'
+        required: false
+        default: false
+        type: boolean
+
+# 보안: pull_request_target을 쓰지 않고 권한을 좁힌다.
+permissions:
+  contents: write
+  pull-requests: read
+
+# 동시에 여러 main PR이 병합돼도 릴리즈 job은 순차 실행한다.
+concurrency:
+  group: main-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    # 자동 트리거는 병합된 PR만, 수동 트리거는 항상 실행한다.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          # 태그 비교를 위해 전체 히스토리와 태그를 가져온다.
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          # 사용자 입력은 env로 받아 JSON 파싱/검증한다.
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_TARGET: ${{ github.event.inputs.target }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # 수동 보정: 입력 버전을 그대로 사용한다.
+            next_tag="$INPUT_VERSION"
+            target="${INPUT_TARGET:-main}"
+          else
+            # 병합된 PR의 release:* label을 추출한다.
+            release_labels=$(printf '%s' "$PR_LABELS" | jq -c '[.[] | select(startswith("release:"))]')
+            count=$(printf '%s' "$release_labels" | jq 'length')
+
+            if [ "$count" -ne 1 ]; then
+              echo "::error::release label이 정확히 하나여야 합니다. 현재 개수: $count"
+              exit 1
+            fi
+
+            release_label=$(printf '%s' "$release_labels" | jq -r '.[0]')
+
+            if [ "$release_label" = "release:skip" ]; then
+              echo "release:skip label이므로 릴리즈를 생성하지 않습니다."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            # 병합 커밋 SHA를 릴리즈 대상으로 삼는다.
+            target="$MERGE_SHA"
+
+            # 최신 vA.B.C 태그를 기준으로 다음 버전을 계산한다.
+            latest_tag="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1)"
+            if [ -z "$latest_tag" ]; then
+              latest_tag="v0.0.0"
+            fi
+            echo "최신 태그: $latest_tag"
+
+            # v 접두사를 떼고 major.minor.patch로 분해한다.
+            version="${latest_tag#v}"
+            major="${version%%.*}"
+            rest="${version#*.}"
+            minor="${rest%%.*}"
+            patch="${rest##*.}"
+
+            case "$release_label" in
+              release:major) major=$((major + 1)); minor=0; patch=0 ;;
+              release:minor) minor=$((minor + 1)); patch=0 ;;
+              release:patch) patch=$((patch + 1)) ;;
+              *) echo "::error::알 수 없는 release label: $release_label"; exit 1 ;;
+            esac
+
+            next_tag="v${major}.${minor}.${patch}"
+          fi
+
+          # 버전 형식을 검증한다.
+          if ! printf '%s' "$next_tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::버전 형식이 올바르지 않습니다: $next_tag (예: v1.2.3)"
+            exit 1
+          fi
+
+          # 이미 존재하는 태그면 실패한다. 자동으로 다음 patch로 넘기지 않는다.
+          if git rev-parse -q --verify "refs/tags/$next_tag" >/dev/null; then
+            echo "::error::태그가 이미 존재합니다: $next_tag. 릴리즈 히스토리 불일치를 숨기지 않습니다."
+            exit 1
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "next_tag=$next_tag" >> "$GITHUB_OUTPUT"
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+          echo "다음 릴리즈 태그: $next_tag (target: $target)"
+
+      - name: Create GitHub Release
+        if: ${{ steps.version.outputs.skip != 'true' }}
+        env:
+          # gh 인증은 GITHUB_TOKEN을 GH_TOKEN으로 넘긴다.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT_TAG: ${{ steps.version.outputs.next_tag }}
+          TARGET: ${{ steps.version.outputs.target }}
+          PRERELEASE: ${{ github.event.inputs.prerelease }}
+        run: |
+          set -euo pipefail
+
+          args=(
+            "$NEXT_TAG"
+            --target "$TARGET"
+            --title "$NEXT_TAG"
+            --generate-notes
+            --fail-on-no-commits
+          )
+
+          if [ "${PRERELEASE:-false}" = "true" ]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "${args[@]}"
+
+          release_url=$(gh release view "$NEXT_TAG" --json url --jq '.url')
+          echo "릴리즈 생성 완료: $release_url"
+
+          {
+            echo "## 릴리즈 생성 완료"
+            echo ""
+            echo "- 버전: \`$NEXT_TAG\`"
+            echo "- 대상: \`$TARGET\`"
+            echo "- URL: $release_url"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-pr-validate.yml
+++ b/.github/workflows/release-pr-validate.yml
@@ -1,0 +1,72 @@
+name: Release PR Validate
+
+# main 대상 PR에 release:* label이 정확히 하나 있는지 검증한다.
+# 자세한 정책은 docs/plans/main-release-workflow.md 참조.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, labeled, unlabeled, reopened, ready_for_review]
+    branches: [main]
+
+# 보안: pull_request_target을 쓰지 않고, 이벤트 payload만 읽으므로 read 권한이면 충분하다.
+permissions:
+  contents: read
+
+jobs:
+  validate-release-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release label
+        env:
+          # 사용자 입력은 shell에 직접 삽입하지 않고 env로 받아 JSON 파싱한다.
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          allowed='["release:major","release:minor","release:patch","release:skip"]'
+
+          # release:* 로 시작하는 label만 추출한다.
+          release_labels=$(printf '%s' "$PR_LABELS" | jq -c '[.[] | select(startswith("release:"))]')
+          count=$(printf '%s' "$release_labels" | jq 'length')
+
+          if [ "$count" -eq 0 ]; then
+            echo "::error::main 대상 PR에는 release:major, release:minor, release:patch, release:skip 중 하나가 필요합니다."
+            echo "현재 release label이 없습니다."
+            exit 1
+          fi
+
+          if [ "$count" -gt 1 ]; then
+            current=$(printf '%s' "$release_labels" | jq -r 'join(", ")')
+            echo "::error::main 대상 PR에는 release:major, release:minor, release:patch, release:skip 중 하나만 필요합니다."
+            echo "현재 label: $current"
+            exit 1
+          fi
+
+          label=$(printf '%s' "$release_labels" | jq -r '.[0]')
+
+          # 정의되지 않은 release:* label은 거부한다.
+          if ! printf '%s' "$allowed" | jq -e --arg l "$label" 'index($l) != null' > /dev/null; then
+            echo "::error::알 수 없는 release label입니다: $label"
+            echo "허용 label: release:major, release:minor, release:patch, release:skip"
+            exit 1
+          fi
+
+          # base는 트리거 필터상 main이지만 한 번 더 방어한다.
+          if [ "$PR_BASE" != "main" ]; then
+            echo "::error::이 워크플로우는 main 대상 PR에서만 동작합니다. 현재 base: $PR_BASE"
+            exit 1
+          fi
+
+          # release:skip이 아니면 head branch 권장 규칙을 확인한다.
+          # 일반 릴리즈는 dev, 긴급 대응은 hotfix/* 를 권장한다(강제 아님).
+          if [ "$label" != "release:skip" ]; then
+            case "$PR_HEAD" in
+              dev | hotfix/*)
+                : ;;
+              *)
+                echo "::warning::일반 릴리즈 PR의 head는 dev 또는 hotfix/* 를 권장합니다. 현재 head: $PR_HEAD" ;;
+            esac
+          fi
+
+          echo "release label 검증 통과: $label (head: $PR_HEAD -> base: $PR_BASE)"


### PR DESCRIPTION
## 📌 PR 제목

`[CHORE] main 릴리즈 자동화 워크플로우 추가`

---

## 🔗 관련 이슈 (Issue)

- Closes #140

---

## ✅ 작업 내용

`main` 브랜치로 PR이 병합되면 `release:*` label을 기준으로 GitHub Release와 `vA.B.C` 태그를 자동 생성하는 워크플로우를 추가했습니다. 운영 배포(`dev -> main`) 시 **label 1개 부착 -> 머지**만으로 버전 계산·태그·릴리즈가 자동 처리됩니다.

새로 추가한 파일은 다음 2개입니다.

| 파일 | 트리거 | 역할 |
| --- | --- | --- |
| `.github/workflows/release-pr-validate.yml` (신규) | `main` 대상 PR `[opened, edited, synchronize, labeled, unlabeled, reopened, ready_for_review]` | `release:*` label이 **정확히 하나**인지 검증. 누락·중복·미정의 label이면 실패, head가 `dev`/`hotfix/*`가 아니면 경고 |
| `.github/workflows/release-create.yml` (신규) | `main` PR 병합(`closed` + `merged == true`) / `workflow_dispatch` | label 기준으로 다음 `vA.B.C` 계산 -> 병합 커밋 SHA에 태그 + Release 생성(`--generate-notes`). `release:skip`은 생성 안 함, 중복 태그는 실패 처리 |

**보안 설계**

- `pull_request_target`을 사용하지 않고, `closed` 이벤트에서 `merged == true`인 PR만 처리합니다.
- 권한을 좁혔습니다. (`validate`: `contents: read`, `create`: `contents: write` / `pull-requests: read`)
- PR label 등 사용자 입력은 shell에 직접 삽입하지 않고 `env` + `jq` JSON 파싱으로 다룹니다.
- `concurrency: main-release`(`cancel-in-progress: false`)로 동시 병합 시에도 릴리즈 job을 순차 실행합니다.

> 새 npm 의존성 없음. GitHub-hosted runner에 기본 설치된 `gh` CLI만 사용해 외부 action 의존성을 최소화했습니다.

---

## 🖥️ 테스트 방법

> Actions는 워크플로우 파일이 기본 브랜치(`dev`/`main`)에 반영된 뒤부터 동작합니다. 1~2는 머지 전 로컬 검증, 3~7은 머지 후 확인입니다.

1. **YAML 파싱 확인**

   ```sh
   ruby -ryaml -e "%w[.github/workflows/release-pr-validate.yml .github/workflows/release-create.yml].each{|f| YAML.load_file(f); puts 'OK: '+f}"
   ```

2. **버전 계산 로직 확인** (`v1.8.4` 기준)
   - `release:major` -> `v2.0.0`, `release:minor` -> `v1.9.0`, `release:patch` -> `v1.8.5`
   - 태그가 하나도 없을 때 `release:patch` -> `v0.0.1`
3. **(머지 후) label 검증** — `dev -> main` 테스트 PR 생성
   - label 없음 -> `Release PR Validate` 실패
   - `release:minor` + `release:patch` 동시 부착 -> 실패
   - `release:patch` 하나만 -> 통과
4. PR 병합 후 `Release Create`가 자동 실행되는지 확인
5. 다음 patch 태그(`vA.B.C`)가 병합 커밋을 가리키는지 확인
6. Releases 탭에 release notes가 생성됐는지 확인
7. `release:skip` PR은 릴리즈를 만들지 않는지 확인

---

## 🚀 머지 후 사용 방법

### 1. 버전 정책 (`A.B.C`)

| 자리 | 이름 | 증가 기준 |
| --- | --- | --- |
| `A` | major | 호환되지 않는 변경, 큰 사용자 플로우 변경, 운영상 breaking change |
| `B` | minor | 신규 기능, 기존 기능의 의미 있는 확장 |
| `C` | patch | 버그 수정, UI 조정, 문구 변경, 작은 개선, 내부 리팩터링 |

> 라이브러리 SemVer처럼 API 호환성만 보지 않고, 웹 서비스 특성상 사용자 경험과 운영 영향도를 함께 기준으로 삼습니다.

### 2. 매 릴리즈마다 하는 일 (2단계)

`main`으로 향하는 PR을 만든 뒤 할 일은 **label 1개 붙이기 -> 머지**가 전부입니다. 버전 계산·태그·Release는 자동입니다.

```txt
[dev -> main PR 생성] -> [release label 1개] -> [Release PR Validate 통과] -> [머지] -> (자동 Release 생성)
```

| 이번 릴리즈 내용 | 붙일 label | 동작 | 예시 결과 (현재 v1.2.3) |
| --- | --- | --- | --- |
| 호환 깨짐 / 큰 플로우 변경 | `release:major` | `A` 증가, `B.C`=`0.0` 초기화 | `v2.0.0` |
| 신규 기능 추가 | `release:minor` | `B` 증가, `C`=`0` 초기화 | `v1.3.0` |
| 버그·문구·작은 수정 | `release:patch` | `C` 증가 | `v1.2.4` |
| 문서/CI라 릴리즈 불필요 | `release:skip` | 릴리즈 생성 안 함 | 릴리즈 안 만듦 |

> `main` 대상 PR에는 `release:*` label 중 **정확히 하나**가 필수입니다. (누락·중복 시 `Release PR Validate` 실패) 워크플로우가 임의로 `patch`를 기본값으로 처리하지 않습니다.

### 3. 예외 케이스

| 상황 | 대응 |
| --- | --- |
| **hotfix** | `hotfix/* -> main` PR 허용(보통 `release:patch`). 머지 후 `main -> dev` 역병합 PR을 별도로 생성 |
| **자동 실패 / 정정** | Actions -> `Release Create` -> Run workflow에서 `version`(예: `v1.2.3`), `target`(기본 `main`), `prerelease`를 입력해 수동 실행 |
| **이미 존재하는 태그** | 자동으로 다음 patch로 넘기지 않고 **실패**. 릴리즈 히스토리 불일치를 숨기지 않으며, 누락 태그는 수동 보정으로 메움 |
| **최초 릴리즈** | 기존 `vA.B.C` 태그가 없으면 `v0.0.0` 기준. 첫 label이 `release:minor`면 `v0.1.0`, `release:patch`면 `v0.0.1`, `release:major`면 `v1.0.0` |

### 4. 1회 설정 (참고)

- **release label 4개**: `release:major` / `release:minor` / `release:patch` / `release:skip` — **이미 생성되어 있습니다.**
- **(권장) 브랜치 보호**: Settings -> Rules -> Rulesets에서 Target `main`에 PR 필수(Required approvals 2), Required status checks에 `validate-release-label` 지정, force push 차단. (status check는 `main` 대상 PR이 한 번 실행된 뒤 목록에 노출됩니다.)
