### PR TITLE
[FIX] 만료된 세션 쿠키로 인한 비로그인 온보딩 진입 불가 수정

### DIFF
--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -1,17 +1,63 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { completeOnboarding } from '@/lib';
+import { cookies } from 'next/headers';
+import { completeOnboarding, HttpError } from '@/lib';
 
 type ActionResult = { success: true } | { success: false; message: string };
 
-/* 온보딩 완료 처리 서버 액션 */
+const SESSION_COOKIE = 'user_session';
+
+/* 세션 재발급 */
+const issueGuestSession = async () => {
+  const response = await fetch(`${process.env.API_PROXY_TARGET}/api/v1/users/sessions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`세션 발급 실패: ${response.status}`);
+  }
+
+  const userSessionValue = response.headers.get('set-cookie')?.match(/user_session=([^;]+)/)?.[1];
+
+  if (!userSessionValue) {
+    throw new Error('세션 쿠키를 발급받지 못했습니다');
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set(SESSION_COOKIE, userSessionValue, {
+    path: '/',
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 365,
+  });
+};
+
+/* 세션이 없거나 만료된 경우(401) 재발급 후 1회 재시도 */
 export const completeOnboardingAction = async (): Promise<ActionResult> => {
   try {
     await completeOnboarding();
     revalidatePath('/');
     return { success: true };
   } catch (error) {
+    // 세션 없음/만료 시 게스트 세션 재발급 후 재시도
+    if (error instanceof HttpError && error.status === 401) {
+      try {
+        await issueGuestSession();
+        await completeOnboarding();
+        revalidatePath('/');
+        return { success: true };
+      } catch (retryError) {
+        console.error('[action] completeOnboarding 재시도 실패:', retryError);
+        return {
+          success: false,
+          message: retryError instanceof Error ? retryError.message : 'Unknown error',
+        };
+      }
+    }
+
     console.error('[action] completeOnboarding 실패:', error);
     return { success: false, message: error instanceof Error ? error.message : 'Unknown error' };
   }

--- a/src/components/pages/Onboarding/Container.tsx
+++ b/src/components/pages/Onboarding/Container.tsx
@@ -71,7 +71,7 @@ export const OnboardingContainer = () => {
           </div>
         </section>
 
-        <footer className="relative z-10 mt-auto flex flex-col gap-[0.8rem] bg-gradient-to-b from-transparent to-white px-[2.4rem] pb-[2rem] pt-[4rem]">
+        <footer className="relative z-10 mt-auto flex flex-col gap-[0.8rem] bg-gradient-to-b from-transparent to-white px-[2.4rem] pb-[2.4rem] pt-[4rem]">
           <Button
             variant={BUTTON_VARIANT.BLACK}
             size="lg"

--- a/src/components/pages/Onboarding/Container.tsx
+++ b/src/components/pages/Onboarding/Container.tsx
@@ -6,11 +6,13 @@ import { useState, useTransition } from 'react';
 import { completeOnboardingAction } from '@/app/actions';
 import { Logo } from '@/assets';
 import { Button, BUTTON_VARIANT } from '@/components';
-import { ONBOARDING_STEPS, PATH_NAME } from '@/constants';
+import { ONBOARDING_STEPS } from '@/constants';
+import { useToastStore } from '@/lib';
 import { StepProgress } from './StepProgress';
 
 export const OnboardingContainer = () => {
   const router = useRouter();
+  const openToast = useToastStore((s) => s.openToast);
   const [isPending, startTransition] = useTransition();
   const [stepIndex, setStepIndex] = useState(0);
 
@@ -25,7 +27,13 @@ export const OnboardingContainer = () => {
   const handleSkipLoginClick = () => {
     startTransition(async () => {
       const result = await completeOnboardingAction();
-      if (result.success) router.push(PATH_NAME.main());
+
+      if (!result.success) {
+        openToast({ type: 'error', message: '잠시 후 다시 시도해주세요.' });
+        return;
+      }
+
+      router.refresh();
     });
   };
 

--- a/src/lib/api/http/httpBase.ts
+++ b/src/lib/api/http/httpBase.ts
@@ -71,9 +71,15 @@ export const httpBase = async <T>(url: string, options: ApiRequestInit = {}): Pr
 
     try {
       const errorBody = await res.json();
-      message = errorBody?.message ?? message;
-      errorCode = errorBody?.errorCode ?? errorBody?.code ?? errorBody?.data?.errorCode;
-      path = errorBody?.path;
+      // 백엔드 에러 응답은 { error: { message, ... } } 형태로 감싸져 옴
+      message = errorBody?.error?.message ?? errorBody?.message ?? message;
+      errorCode =
+        errorBody?.error?.errorCode ??
+        errorBody?.error?.code ??
+        errorBody?.errorCode ??
+        errorBody?.code ??
+        errorBody?.data?.errorCode;
+      path = errorBody?.error?.path ?? errorBody?.path;
     } catch {
       // non-json 에러 응답 대비
     }


### PR DESCRIPTION
## 📌 PR 제목

[FIX] 만료된 세션 쿠키로 인한 비로그인 온보딩 진입 불가 수정

---

## 🔗 관련 이슈 (Issue)

- Closes #147

---

## ✅ 작업 내용

온보딩 마지막 화면에서 **로그인 없이 시작하기** 버튼을 눌러도 메인으로 넘어가지 않던 문제를 수정했습니다.

- **원인**: 브라우저에 만료·무효한 `user_session` 쿠키가 남아 있으면 proxy가 세션을 갱신하지 않아(쿠키가 "없을 때만" 발급), 온보딩 완료 요청이 401로 실패하고 버튼이 아무 반응 없이 멈춤. 게다가 `httpBase`가 백엔드 에러 형식(`{ error: { message } }`)을 읽지 못해 모든 에러가 `API Error`로 가려져 디버깅도 어려웠음.
- `src/app/actions/users.ts`: `completeOnboardingAction`이 401을 만나면 게스트 세션을 재발급(백엔드 Set-Cookie를 읽어 쿠키에 반영)하고 1회 재시도하도록 자가 치유 로직 추가.
- `src/lib/api/http/httpBase.ts`: 백엔드 에러 envelope(`error.message` / `error.errorCode` / `error.path`)를 우선 파싱하도록 수정.
- `src/components/pages/Onboarding/Container.tsx`: 실패 시 에러 토스트 노출, 성공 시 `router.refresh()`로 메인 전환. 불필요해진 `router.push` / `PATH_NAME` 제거.

> Server Action(`users.ts`) 변경 사항이며, Client/Server 컴포넌트 경계나 외부 타입 변경은 없습니다.

---

## 🖥️ 테스트 방법

1. 브라우저에 유효하지 않은 `user_session` 쿠키를 설정 (예: 개발자도구 > Application > Cookies에서 `user_session` 값을 임의 문자열로 변경)
2. `/` 접속 → 온보딩 화면 노출 확인
3. 마지막 단계에서 **로그인 없이 시작하기** 클릭
4. 새 게스트 세션이 발급되며 메인 화면으로 정상 전환되는지 확인
5. (추가) 쿠키를 모두 삭제한 신규 진입에서도 동일하게 메인으로 넘어가는지 확인

검증: 무효 쿠키 상태로 서버 액션 직접 호출 시 HTTP 200 + 새 `user_session` 발급 + 메인(MainBooksShell) 렌더 확인. `eslint` / `tsc --noEmit` 통과.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 온보딩 진행 중 인증 오류 발생 시 자동으로 재시도되는 기능이 추가되었습니다.
  * 온보딩 실패 시 토스트 알림으로 에러 메시지가 표시됩니다.

* **개선사항**
  * 온보딩 완료 후 페이지가 자동으로 새로고침됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->