### PR TITLE
[FIX] ChatCard 우측 상단 북마크·새로고침 아이콘 제거

### DIFF
--- a/src/components/common/ChatCard/ChatCard.stories.tsx
+++ b/src/components/common/ChatCard/ChatCard.stories.tsx
@@ -1,5 +1,4 @@
 import { type Meta, type StoryObj } from '@storybook/nextjs-vite';
-import { fn } from 'storybook/test';
 import { ChatCard } from './ChatCard';
 
 const meta = {
@@ -27,18 +26,12 @@ const meta = {
       options: ['default', 'loading', 'error'],
       description: '카드 상태',
     },
-    bookmarked: {
-      control: 'boolean',
-      description: '북마크 여부',
-    },
   },
   args: {
     color: 'teal',
     status: 'default',
-    bookmarked: false,
     date: '25.10.10',
     summary: '대화한 내용 간단 요약 어쩌구 저쩌구',
-    onRefresh: fn(),
   },
 } satisfies Meta<typeof ChatCard>;
 
@@ -46,13 +39,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
-
-export const Bookmarked: Story = {
-  name: 'Default / Bookmarked',
-  args: {
-    bookmarked: true,
-  },
-};
 
 export const Loading: Story = {
   args: {

--- a/src/components/common/ChatCard/ChatCard.tsx
+++ b/src/components/common/ChatCard/ChatCard.tsx
@@ -1,9 +1,7 @@
-import { BookmarkCheckIcon, ReloadIcon } from '@/components';
 import { cn } from '@/lib';
 import {
   CHAT_CARD_STATUS,
   type ChatCardColor,
-  chatCardIconColor,
   type ChatCardStatus,
   chatCardTitleColor,
   chatCardVariants,
@@ -12,24 +10,20 @@ import {
 export type ChatCardProps = {
   color?: ChatCardColor;
   status?: ChatCardStatus;
-  bookmarked?: boolean;
   bookTitle?: string;
   date?: string;
   summary?: string;
   className?: string;
-  onRefresh?: () => void;
 };
 
 export const ChatCard = (props: ChatCardProps) => {
   const {
     color = 'teal',
     status = CHAT_CARD_STATUS.DEFAULT,
-    bookmarked = false,
     bookTitle,
     date,
     summary,
     className,
-    onRefresh,
   } = props;
 
   const [isDefault, isLoading, isError] = [
@@ -44,12 +38,12 @@ export const ChatCard = (props: ChatCardProps) => {
 
       <div className="relative flex min-w-0 flex-1 flex-col">
         {(isDefault || isLoading) && (bookTitle ?? date) && (
-          <p className="body2-semibold line-clamp-1 w-full shrink-0 break-words tracking-[-0.042rem] text-[rgba(0,0,0,0.27)]">
+          <p className="body2-semibold line-clamp-1 w-full shrink-0 break-words tracking-[-0.042rem] text-gray-alpha-300">
             {bookTitle ?? date}
           </p>
         )}
         {isError && (
-          <p className="body2-semibold shrink-0 tracking-[-0.042rem] text-[rgba(0,0,0,0.27)]">
+          <p className="body2-semibold shrink-0 tracking-[-0.042rem] text-gray-alpha-300">
             새로고침이 필요해요
           </p>
         )}
@@ -87,24 +81,6 @@ export const ChatCard = (props: ChatCardProps) => {
           </p>
         )}
       </div>
-
-      {isDefault && bookmarked && (
-        <BookmarkCheckIcon color={color} className="relative shrink-0 size-[2.4rem]" />
-      )}
-
-      {isError && (
-        <button
-          type="button"
-          aria-label="새로고침"
-          onClick={(e) => {
-            e.preventDefault();
-            onRefresh?.();
-          }}
-          className="relative shrink-0 cursor-pointer"
-        >
-          <ReloadIcon className={cn('size-[2.4rem]', chatCardIconColor[color])} />
-        </button>
-      )}
     </article>
   );
 };

--- a/src/components/common/ChatCard/chatCardVariants.ts
+++ b/src/components/common/ChatCard/chatCardVariants.ts
@@ -51,16 +51,6 @@ export const chatCardTitleColor: Record<ChatCardColor, string> = {
   blue: 'text-sub-blue',
 };
 
-export const chatCardIconColor: Record<ChatCardColor, string> = {
-  teal: 'fill-sub-teal',
-  magenta: 'fill-sub-magenta',
-  yellow: 'fill-sub-yellow',
-  sky: 'fill-sub-sky',
-  green: 'fill-sub-green',
-  purple: 'fill-sub-purple',
-  blue: 'fill-sub-blue',
-};
-
 export const CHAT_CARD_COLOR_SEQUENCE: readonly ChatCardColor[] = [
   CHAT_CARD_COLOR.TEAL,
   CHAT_CARD_COLOR.PURPLE,

--- a/src/components/pages/BookDetail/Container.tsx
+++ b/src/components/pages/BookDetail/Container.tsx
@@ -189,7 +189,6 @@ export const BookDetailContainer = (props: Props) => {
           <ol className="flex list-none flex-col gap-[0.8rem] pb-[4rem]">
             {sessions.map((session, index) => {
               const color = CHAT_CARD_COLOR_SEQUENCE[index % CHAT_CARD_COLOR_SEQUENCE.length];
-              const hasSummary = session.status === 'SUMMARIZED' || !!session.latestSummaryContent;
               const path = getSessionPath(session.sessionId, session.status);
 
               return (
@@ -204,7 +203,6 @@ export const BookDetailContainer = (props: Props) => {
                       status={SESSION_STATUS_TO_CARD[session.status]}
                       date={formatDate(session.lastChattedDate)}
                       summary={session.title}
-                      bookmarked={hasSummary}
                     />
                   </button>
                 </li>

--- a/src/components/pages/Main/SessionList.tsx
+++ b/src/components/pages/Main/SessionList.tsx
@@ -108,12 +108,7 @@ export const SessionList = (props: Props) => {
                 className="w-full cursor-pointer text-left"
                 onClick={() => void onNavigate(path)}
               >
-                <ChatCard
-                  color={color}
-                  bookTitle={summary.bookTitle}
-                  summary={summary.title}
-                  bookmarked
-                />
+                <ChatCard color={color} bookTitle={summary.bookTitle} summary={summary.title} />
               </button>
             </li>
           );


### PR DESCRIPTION
## 📌 PR 제목

[FIX] ChatCard 우측 상단 북마크·새로고침 아이콘 제거

---

## 🔗 관련 이슈 (Issue)

- Closes #149

---

## ✅ 작업 내용

새 디자인(Figma)에 맞춰 `ChatCard` 우측 상단의 북마크 아이콘과 에러 상태 새로고침 버튼을 제거했습니다.

- `ChatCard.tsx`: 북마크 아이콘(`BookmarkCheckIcon`)·새로고침 버튼(`ReloadIcon`) 렌더링 제거, 미사용 `bookmarked`·`onRefresh` prop 및 관련 import 정리
- `ChatCard.tsx`: 제목 색상을 하드코딩값(`rgba(0,0,0,0.27)`)에서 디자인 토큰 `text-gray-alpha-300`(`rgba(23,28,27,0.3)`)으로 정렬
- `chatCardVariants.ts`: 더 이상 사용하지 않는 `chatCardIconColor` 맵 제거
- `SessionList.tsx` / `BookDetail/Container.tsx`: 제거된 `bookmarked` prop 및 미사용 `hasSummary` 변수 정리
- `ChatCard.stories.tsx`: `bookmarked`·`onRefresh` 인자와 `Bookmarked` 스토리 제거

> 참고: `loading`·`error` 상태 텍스트는 `BookDetail`에서 `status` prop으로 사용 중이라 그대로 유지하고, 에러 상태의 새로고침 `버튼`만 제거했습니다. 타입 변경은 `ChatCardProps`에서 prop 2개(`bookmarked`, `onRefresh`) 제거뿐이며 Server/Client 컴포넌트 경계 변경은 없습니다.

---

## 🖥️ 테스트 방법

1. Storybook에서 `Common/ChatCard` 확인 → Default 카드에 북마크/새로고침 아이콘이 없는지 확인
2. 마이페이지 감상 기록 목록(`Records` / `ListContainer`) → 카드에 아이콘 없이 제목·요약만 노출되는지 확인
3. 홈 세션 목록(`SessionList`) → 카드 우측 상단에 북마크 아이콘이 사라졌는지 확인
4. 책 상세(`BookDetail`) → loading/error 상태 카드가 정상 노출되며 새로고침 버튼만 사라졌는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅 카드에서 북마크 기능 및 새로고침 버튼 제거

* **스타일**
  * 채팅 카드의 텍스트 색상 및 스타일 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->