### PR TITLE
[FEAT] 마이페이지 감상기록 세션 제목 표시 및 ID 연결

### DIFF
--- a/src/components/pages/Mypage/ListContainer.tsx
+++ b/src/components/pages/Mypage/ListContainer.tsx
@@ -136,7 +136,7 @@ const RecordsList = (props: RecordsListProps) => {
               <ChatCard
                 color={chatCardColorByIndex(index)}
                 bookTitle={record.bookTitle}
-                summary={record.content}
+                summary={record.sessionTitle}
               />
             </Link>
           </li>

--- a/src/components/pages/Mypage/Records.tsx
+++ b/src/components/pages/Mypage/Records.tsx
@@ -44,7 +44,7 @@ export const Records = (props: Props) => {
                 <ChatCard
                   color={chatCardColorByIndex(index)}
                   bookTitle={record.bookTitle}
-                  summary={record.content}
+                  summary={record.sessionTitle}
                 />
               </Link>
             </li>

--- a/src/lib/api/services/summaries/summaries.zod.ts
+++ b/src/lib/api/services/summaries/summaries.zod.ts
@@ -4,7 +4,7 @@ import { createResponseSchema } from '@/lib';
 export const SummaryListItemSchema = z.object({
   summaryId: z.number(),
   bookTitle: z.string(),
-  content: z.string(),
+  sessionTitle: z.string(),
   createdAt: z.string(),
 });
 


### PR DESCRIPTION
## 📌 PR 제목

> 마이페이지 감상기록 세션 제목 표시 및 ID 연결

---

## 🔗 관련 이슈 (Issue)

해당 PR이 어떤 이슈를 해결하는지 연결해주세요.

- Closes #153 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 요약 목록에서 표시되는 항목이 콘텐츠에서 세션 제목으로 변경되었습니다.
  * API 응답 스키마가 업데이트되어 세션 제목 정보를 올바르게 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->