### PR TITLE
[FIX] 채팅 화면 헤더/입력창 Fixed로 전환

### DIFF
--- a/src/components/common/Header/headerVariants.ts
+++ b/src/components/common/Header/headerVariants.ts
@@ -16,8 +16,7 @@ export const headerVariants = cva(
         [HEADER_VARIANT.HOME]:
           'flex justify-between items-center border-b border-white bg-white/5 backdrop-blur-md px-[2.4rem] py-[1.6rem]',
         [HEADER_VARIANT.BACK]: 'bg-primary-base pl-[1.8rem] pr-[2.4rem] py-[1.8rem]',
-        [HEADER_VARIANT.CHAT]:
-          'relative justify-between bg-text-white pl-[1.8rem] pr-[2.4rem] py-[1.8rem]',
+        [HEADER_VARIANT.CHAT]: 'justify-between bg-text-white pl-[1.8rem] pr-[2.4rem] py-[1.8rem]',
       },
     },
     defaultVariants: {

--- a/src/components/pages/Chat/Container.tsx
+++ b/src/components/pages/Chat/Container.tsx
@@ -405,15 +405,14 @@ export const ChatContainer = () => {
   }, []);
 
   return (
-    <div className="relative min-h-screen overflow-hidden">
-      <div className="bg-text-white pointer-events-none absolute inset-x-0 bottom-0 top-[30%]" />
+    <div className="relative min-h-dvh">
+      <div className="bg-text-white pointer-events-none fixed bottom-0 left-1/2 top-[30%] z-0 w-full max-w-mobile-responsive -translate-x-1/2" />
 
-      <div className="relative z-10 flex h-screen flex-col">
+      <div className="relative z-10">
         <Header
           variant={HEADER_VARIANT.CHAT}
           onBack={() => router.replace(PATH_NAME.main())}
           progress={progress}
-          spacerClassName="hidden"
           rightSlot={
             canSummarize ? (
               <div className="relative flex shrink-0 flex-col items-end">
@@ -447,10 +446,10 @@ export const ChatContainer = () => {
             />
           </div>
         ) : null}
-        <div className="h-[2rem] bg-text-white shrink-0" />
+        <div className="h-[2rem] bg-text-white" />
 
         <main
-          className="bg-text-white scrollbar-hide min-h-0 flex-1 overflow-y-auto px-[2.4rem] pt-[1.6rem]"
+          className="bg-text-white px-[2.4rem] pt-[1.6rem]"
           style={{ paddingBottom: `${footerHeight + CHAT_BOTTOM_GAP}px` }}
         >
           <div ref={topRef} />
@@ -473,14 +472,14 @@ export const ChatContainer = () => {
             )}
             <div
               ref={bottomRef}
-              style={{ scrollMarginBottom: `${extraFooterOffset + CHAT_BOTTOM_GAP}px` }}
+              style={{ scrollMarginBottom: `${footerHeight + CHAT_BOTTOM_GAP}px` }}
             />
           </div>
         </main>
 
         <footer
           ref={footerRef}
-          className="bg-white/68 bg-gradient-footer absolute inset-x-0 bottom-0 z-20 rounded-t-[24px] border border-white/35 border-b-0 px-[2.4rem] py-8 shadow-[0_-10px_36px_-14px_rgba(23,28,27,0.06)] backdrop-blur-[42px] backdrop-saturate-125"
+          className="bg-white/68 bg-gradient-footer fixed bottom-0 left-1/2 z-20 w-full max-w-mobile-responsive -translate-x-1/2 rounded-t-[24px] border border-white/35 border-b-0 px-[2.4rem] py-8 shadow-[0_-10px_36px_-14px_rgba(23,28,27,0.06)] backdrop-blur-[42px] backdrop-saturate-125"
         >
           <TextfieldChat
             bgVariant={CHAT_BG_VARIANT.WHITE}


### PR DESCRIPTION
## 📌 PR 제목

[FIX] 채팅 화면 헤더/입력창 Fixed로 전환

---

## 🔗 관련 이슈 (Issue)

- Closes #164

---

## ✅ 작업 내용

iOS 사파리 등에서 채팅 화면을 스크롤하면 헤더(상단)와 입력창(하단)이 고정되지 않고 콘텐츠와 함께 밀려 보이는 문제를 수정했습니다.

기존에는 `h-dvh` 컨테이너 + `<main>` 내부 스크롤(`overflow-y-auto`) 방식이라 모바일 동적 뷰포트(주소창 토글 등)에 취약했습니다. 이를 **문서(뷰포트) 스크롤 + fixed 헤더/입력창** 구조로 전환했습니다. 전역 `layout.tsx`는 건드리지 않아 다른 페이지에는 영향이 없습니다.

**`src/components/pages/Chat/Container.tsx`**

- 컨테이너의 높이 가두기(`flex h-dvh flex-col`)와 `<main>` 내부 스크롤(`flex-1 overflow-y-auto`)을 제거해 문서 스크롤로 전환
- 입력창 `<footer>`를 `absolute` → `fixed` + 모바일 폭 보정(`left-1/2 max-w-mobile-responsive -translate-x-1/2`)으로 변경 (backdrop-blur 글래스 디자인은 그대로 유지)
- 헤더 spacer 복원(`spacerClassName="hidden"` 제거)으로 헤더 높이만큼 본문 상단 여백 확보
- 배경 레이어를 `absolute` → `fixed`(화면 기준) + 폭 보정으로 변경
- `bottomRef`의 `scrollMarginBottom`을 fixed 입력창 전체 높이 기준으로 보정

**`src/components/common/Header/headerVariants.ts`**

- CHAT variant의 `relative` 제거 → base의 `fixed` 복원
- tailwind-merge가 position 충돌에서 뒤 클래스(`relative`)를 채택해 헤더가 fixed로 동작하지 않던 것이 근본 원인이었습니다. CHAT variant는 채팅 화면에서만 사용하므로 다른 화면 영향 없음

> Server / Client 컴포넌트 경계 변경 없음, 타입 변경 없음.

---

## 🖥️ 테스트 방법

1. 모바일 뷰(또는 iOS 사파리)로 `/chat` 접속
2. 대화를 스크롤하며 **헤더(상단)·입력창(하단)이 고정**되는지 확인
3. 입력창에 여러 줄 입력 시, 본문 하단 여백이 입력창 높이에 맞춰 보정되는지 확인

Playwright 실측 결과: 헤더·입력창 `position: fixed`, 스크롤 900px 시 위치 불변(헤더 top `0`, 입력창 bottom = 뷰포트 높이), 콘솔 에러 0건.

> ⚠️ iOS 사파리에서 입력창을 탭해 **키보드를 올린 상태**는 `visualViewport` 보정이 없어 별도 확인이 필요합니다. 입력창이 키보드에 가려질 경우 후속 작업 대상입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Style**
  * 채팅 페이지의 레이아웃 및 스크롤 동작을 개선했습니다.
  * 헤더 스타일을 조정하고 화면 높이 계산 방식을 최적화했습니다.
  * 푸터의 위치 지정을 개선하여 더 안정적인 고정 UI 렌더링을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->